### PR TITLE
feat(timetable): 시간표 레이아웃 구현

### DIFF
--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -70,14 +70,11 @@ const TimetablePage = () => {
     setUserLectures({ reservation: updatedReservations, wishlist: userWishlist });
   }, []);
 
-  const timeSlots = Array.from({ length: 18 }, (_, i) => {
-    const hour = Math.floor(i / 2) + 9;
-    const minute = i % 2 === 0 ? '00' : '30';
-    const nextMinute = i % 2 === 0 ? '30' : '00';
-    const nextHour = i % 2 === 0 ? hour : hour + 1;
+  const timeSlots = Array.from({ length: 9 }, (_, i) => {
+    const hour = i + 9;
     return {
-      start: `${String(hour).padStart(2, '0')}:${minute}`,
-      end: `${String(nextHour).padStart(2, '0')}:${nextMinute}`,
+      start: `${String(hour).padStart(2, '0')}:00`,
+      end: `${String(hour + 1).padStart(2, '0')}:00`,
     };
   });
 
@@ -98,7 +95,7 @@ const TimetablePage = () => {
 
         {timeSlots.map(({ start, end }, i) => (
           <Fragment key={`time-${start}-${end}`}>
-            <div className="border border-gray-300 bg-gray-100 dark:bg-gray-600 p-3 text-center font-medium">
+            <div className="flex justify-center items-center border border-gray-300 bg-gray-100 dark:bg-gray-600 p-3 text-center font-medium h-16">
               {start} ~ {end}
             </div>
 
@@ -128,11 +125,11 @@ const TimetablePage = () => {
               if (lecture) {
                 const rowSpan =
                   (new Date(lecture.end_time).getTime() - new Date(lecture.start_time).getTime()) /
-                  (30 * 60 * 1000);
+                  (60 * 60 * 1000);
 
                 for (let k = 0; k < rowSpan; k++) {
                   const occupiedTime = new Date(
-                    new Date(lecture.start_time).getTime() + k * 30 * 60 * 1000,
+                    new Date(lecture.start_time).getTime() + k * 60 * 60 * 1000,
                   ).toLocaleTimeString('ko-KR', {
                     hour: '2-digit',
                     minute: '2-digit',

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -23,6 +23,7 @@ interface UserLectures {
 
 const TimetablePage = () => {
   const [userLectures, setUserLectures] = useState<UserLectures>({ reservation: [], wishlist: [] });
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
   const router = useRouter();
   const currentUserId = 222; // 현재 로그인한 유저 ID 가져오는 로직 추가
 
@@ -81,92 +82,175 @@ const TimetablePage = () => {
   const occupiedSlots = new Set();
 
   return (
-    <div className="p-10">
-      <h1 className="text-xl font-bold mb-4">컴퍼런스 일정 시간표</h1>
+    <div className="flex gap-4">
+      <div className="flex-2 p-10">
+        <h1
+          className={`text-xl font-bold mb-4 transition-all ${
+            selectedTime ? 'text-left' : 'text-center w-full'
+          }`}
+        >
+          컴퍼런스 일정 시간표
+        </h1>
 
-      <div
-        className="grid border border-gray-300"
-        style={{ gridTemplateColumns: '140px repeat(3, 1fr)' }}
-      >
-        <div className="border border-gray-300 p-3 font-bold text-center">Time</div>
-        <div className="border border-gray-300 p-3 font-bold text-center">Day1</div>
-        <div className="border border-gray-300 p-3 font-bold text-center">Day2</div>
-        <div className="border border-gray-300 p-3 font-bold text-center">Day3</div>
+        <div
+          className="grid border border-gray-300"
+          style={{ gridTemplateColumns: '140px repeat(3, 1fr)' }}
+        >
+          <div className="border border-gray-300 p-3 font-bold text-center">Time</div>
+          <div className="border border-gray-300 p-3 font-bold text-center">Day1</div>
+          <div className="border border-gray-300 p-3 font-bold text-center">Day2</div>
+          <div className="border border-gray-300 p-3 font-bold text-center">Day3</div>
 
-        {timeSlots.map(({ start, end }, i) => (
-          <Fragment key={`time-${start}-${end}`}>
-            <div className="flex justify-center items-center border border-gray-300 bg-gray-100 dark:bg-gray-600 p-3 text-center font-medium h-16">
-              {start} ~ {end}
-            </div>
+          {timeSlots.map(({ start, end }, i) => (
+            <Fragment key={`time-${start}-${end}`}>
+              <div className="flex justify-center items-center border border-gray-300 bg-gray-100 dark:bg-gray-600 p-3 text-center font-medium">
+                {start} ~ {end}
+              </div>
 
-            {Array.from({ length: 3 }, (_, j) => {
-              const day = j + 1;
+              {Array.from({ length: 3 }, (_, j) => {
+                const day = j + 1;
 
-              // 이미 배치된 강의는 렌더링 x
-              if (occupiedSlots.has(`${day}-${start}`)) {
-                return null;
-              }
+                // 이미 배치된 강의는 렌더링 x
+                if (occupiedSlots.has(`${day}-${start}`)) {
+                  return null;
+                }
 
-              const lecture = userLectures.reservation.find((lec) => {
-                const formattedStartTime = new Date(lec.start_time).toLocaleTimeString('ko-KR', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: false,
-                });
-                const formattedEndTime = new Date(lec.end_time).toLocaleTimeString('ko-KR', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: false,
-                });
-
-                return lec.day === day && formattedStartTime <= start && formattedEndTime > start;
-              });
-
-              if (lecture) {
-                const rowSpan =
-                  (new Date(lecture.end_time).getTime() - new Date(lecture.start_time).getTime()) /
-                  (60 * 60 * 1000);
-
-                for (let k = 0; k < rowSpan; k++) {
-                  const occupiedTime = new Date(
-                    new Date(lecture.start_time).getTime() + k * 60 * 60 * 1000,
-                  ).toLocaleTimeString('ko-KR', {
+                const lecture = userLectures.reservation.find((lec) => {
+                  const formattedStartTime = new Date(lec.start_time).toLocaleTimeString('ko-KR', {
                     hour: '2-digit',
                     minute: '2-digit',
                     hour12: false,
                   });
-                  occupiedSlots.add(`${day}-${occupiedTime}`);
-                }
+                  const formattedEndTime = new Date(lec.end_time).toLocaleTimeString('ko-KR', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: false,
+                  });
 
-                return (
-                  <div
-                    key={`day-${day}-time-${start}`}
-                    className="flex flex-col justify-center gap-2 border border-gray-300 p-4 cursor-pointer"
-                    style={{ gridRow: `span ${rowSpan}` }}
-                    onClick={() => router.push(`/lecture/${lecture?.id}`)} // 강의 상세 모달로 변경하기
-                  >
-                    <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
-                    <span>{lecture?.title}</span>
-                    <div className="flex justify-between w-full">
-                      <p>{lecture.speaker}</p>
-                      <p>
-                        인원수 {lecture.count} / {lecture.total}
-                      </p>
+                  return lec.day === day && formattedStartTime <= start && formattedEndTime > start;
+                });
+
+                if (lecture) {
+                  const rowSpan =
+                    (new Date(lecture.end_time).getTime() -
+                      new Date(lecture.start_time).getTime()) /
+                    (60 * 60 * 1000);
+
+                  for (let k = 0; k < rowSpan; k++) {
+                    const occupiedTime = new Date(
+                      new Date(lecture.start_time).getTime() + k * 60 * 60 * 1000,
+                    ).toLocaleTimeString('ko-KR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hour12: false,
+                    });
+                    occupiedSlots.add(`${day}-${occupiedTime}`);
+                  }
+
+                  return (
+                    <div
+                      key={`day-${day}-time-${start}`}
+                      className="flex flex-col justify-center gap-2 border border-gray-300 p-4 cursor-pointer"
+                      style={{ gridRow: `span ${rowSpan}` }}
+                      onClick={() => router.push(`/lecture/${lecture?.id}`)} // 강의 상세 모달로 변경하기
+                    >
+                      <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
+                      <span>{lecture?.title}</span>
+                      <div className="flex justify-between w-full">
+                        <p>{lecture.speaker}</p>
+                        <p>
+                          인원수 {lecture.count} / {lecture.total}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                );
-              } else {
-                return (
-                  <div
-                    key={`day-${day}-time-${start}`}
-                    className="border border-gray-300 p-3 bg-gray-100 dark:bg-gray-600 hover:bg-gray-300"
-                  />
-                );
-              }
-            })}
-          </Fragment>
-        ))}
+                  );
+                } else {
+                  return (
+                    <div
+                      key={`day-${day}-time-${start}`}
+                      className="border border-gray-300 p-3 bg-gray-100 dark:bg-gray-600 hover:bg-gray-300"
+                      onClick={() => {
+                        setSelectedTime(`Day${day} ${start}`);
+                        console.log(selectedTime);
+                      }}
+                    />
+                  );
+                }
+              })}
+            </Fragment>
+          ))}
+        </div>
       </div>
+
+      {selectedTime && (
+        <div className="flex-1 p-4 pt-10 bg-gray-50 h-screen dark:bg-gray-900">
+          <h3 className=" text-md font-semibold">즐찾 목록</h3>
+          <div className="h-1/3 overflow-auto">
+            <ul className="mt-2 border">
+              {userLectures.wishlist.map((lecture) => (
+                <li key={lecture.id} className="p-2 border-b border-gray-200">
+                  <div className="flex items-center gap-2">
+                    <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
+                    <span className="text-xs">
+                      {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}{' '}
+                      -{' '}
+                      {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}
+                    </span>
+                  </div>
+                  <span>{lecture?.title}</span>
+                  <div className="flex justify-between w-full">
+                    <p>{lecture.speaker}</p>
+                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                      강의 신청
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <h3 className="pt-10 text-md font-semibold">공석 추천 목록</h3>
+          <div className="h-1/2 overflow-auto">
+            <ul className="mt-2 border">
+              {/* 추천 강의로 바꾸기 */}
+              {userLectures.wishlist.map((lecture) => (
+                <li key={lecture.id} className="p-2 border-b border-gray-200">
+                  <div className="flex items-center gap-2">
+                    <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
+                    <span className="text-xs">
+                      {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}{' '}
+                      -{' '}
+                      {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}
+                    </span>
+                  </div>
+                  <span>{lecture?.title}</span>
+                  <div className="flex justify-between w-full">
+                    <p>{lecture.speaker}</p>
+                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                      강의 신청
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/dummyData/timetable/getTimetable.json
+++ b/src/app/dummyData/timetable/getTimetable.json
@@ -6,7 +6,11 @@
       "lecture_id": 1,
       "title": "강의 제목1",
       "start_time": "2025-03-04T10:00:00",
-      "end_time": "2025-03-04T12:00:00"
+      "end_time": "2025-03-04T12:00:00",
+      "location": "101호",
+      "speaker": "신짱구",
+      "count": 12,
+      "total": 45
     },
     {
       "id": 2,
@@ -14,7 +18,11 @@
       "lecture_id": 1,
       "title": "강의 제목1",
       "start_time": "2025-03-04T10:00:00",
-      "end_time": "2025-03-04T12:00:00"
+      "end_time": "2025-03-04T12:00:00",
+      "location": "101호",
+      "speaker": "신짱구",
+      "count": 12,
+      "total": 45
     },
     {
       "id": 3,
@@ -22,7 +30,11 @@
       "lecture_id": 3,
       "title": "강의 제목3",
       "start_time": "2025-03-06T09:00:00",
-      "end_time": "2025-03-06T11:00:00"
+      "end_time": "2025-03-06T11:00:00",
+      "location": "303호",
+      "speaker": "김철수",
+      "count": 28,
+      "total": 60
     }
   ],
 
@@ -33,7 +45,11 @@
       "lecture_id": 2,
       "title": "강의 제목2",
       "start_time": "2025-03-05T14:00:00",
-      "end_time": "2025-03-05T16:00:00"
+      "end_time": "2025-03-05T16:00:00",
+      "location": "101호",
+      "speaker": "신짱구",
+      "count": 12,
+      "total": 45
     },
     {
       "id": 2,
@@ -41,7 +57,11 @@
       "lecture_id": 2,
       "title": "강의 제목2",
       "start_time": "2025-03-05T14:00:00",
-      "end_time": "2025-03-05T16:00:00"
+      "end_time": "2025-03-05T16:00:00",
+      "location": "202호",
+      "speaker": "맹구",
+      "count": 14,
+      "total": 20
     }
   ]
 }

--- a/src/app/dummyData/timetable/getTimetableRecommand.json
+++ b/src/app/dummyData/timetable/getTimetableRecommand.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "lecture_id": 1,
+      "title": "추천강의제목1",
+      "start_time": "2025-03-05T10:00:00",
+      "end_time": "2025-03-05T11:00:00",
+      "location": "101호",
+      "speaker": "홍길동"
+    },
+    {
+      "lecture_id": 2,
+      "title": "추천강의제목2",
+      "start_time": "2025-03-05T13:00:00",
+      "end_time": "2025-03-05T15:00:00",
+      "location": "201호",
+      "speaker": "고길동"
+    }
+  ]
+}


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/timetable` → `dev`

<br/>

## ✅ 작업 내용

- 와이어프레임을 기반으로 시간표 페이지 레이아웃을 구현했습니다.
- 시간표의 빈 부분을 누르면, 오른쪽에 패널이 나타나며 즐겨찾기 목록과 공석 추천 목록이 나타납니다.
- 즐겨찾기 목록과 공석 추천 목록의 아이템이 많아지면 전체 스크롤이 아닌, 목록 내에서 스크롤되게 구현했습니다.
- 창의 너비가 줄어들 때, 양 옆의 여백이 일정하게 줄어들도록 하였고, 모바일 반응형은 아직 정확한 기준이 나오지 않아 구현하지 않았습니다.

<br/>

## 🌠 이미지 첨부

<img width="1152" alt="스크린샷 2025-03-07 오후 6 16 52" src="https://github.com/user-attachments/assets/810523d9-421e-497b-aae2-78dd76dfc9ca" />
<img width="1151" alt="스크린샷 2025-03-07 오후 6 17 03" src="https://github.com/user-attachments/assets/068b6c56-1223-4dd7-8428-133fef968065" />

<br/>

## ✏️ 앞으로의 과제

- 강의 목록

<br/>

## 📌 이슈 링크
- [`feat/timetable` #11 ]
