### PR TITLE
feat(card component): 카드 컴포넌트 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,12 @@ const nextConfig: NextConfig = {
   },
 
   images: {
-    domains: ['dyns.co.kr'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'dyns.co.kr',
+      },
+    ],
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,17 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,
       issuer: /\.[jt]sx?$/,
-      use: ["@svgr/webpack"],
+      use: ['@svgr/webpack'],
     });
     return config;
+  },
+
+  images: {
+    domains: ['dyns.co.kr'],
   },
 };
 

--- a/src/app/(route)/(main)/page.tsx
+++ b/src/app/(route)/(main)/page.tsx
@@ -3,3 +3,19 @@ const Page = () => {
 };
 
 export default Page;
+
+// 나중에 카드 컴포넌트 사용하실 때 아래처럼 사용하시면 됩니다
+// <Card
+//   key={lecture.id}
+//   id={lecture.id}
+//   image={lecture.image}
+//   title={lecture.title}
+//   category={lecture.category}
+//   time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
+//   showWish={true}
+// >
+//   <div className="flex items-center mt-1">
+//     <div className="w-4 h-4 bg-gray-300 rounded-full mr-2"></div>
+//     <p className="text-sm font-semibold">{lecture.speakerName}</p>
+//   </div>
+// </Card>;

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import response from '@/dummyData/lecture-list/getLectureList.json';
-import { useRouter } from 'next/navigation';
+import Card from '@/_components/Card/Card';
 
 interface LectureListProps {
   id: number;
@@ -10,12 +10,12 @@ interface LectureListProps {
   category: string;
   start_time: string;
   end_time: string;
-  location: string;
+  speakerName: string;
+  image: string;
 }
 
 const LectureListPage = () => {
   const [lectures, setLectures] = useState<LectureListProps[]>([]);
-  const router = useRouter();
 
   useEffect(() => {
     // const fetchLectures = async () => {
@@ -35,22 +35,63 @@ const LectureListPage = () => {
     setLectures(response.data.lectures);
   }, []);
 
+  const groupByTime = (lectures: LectureListProps[]) => {
+    return lectures.reduce(
+      (acc, lecture) => {
+        const date = new Date(lecture.start_time);
+        const startHour = date.getHours();
+        const timeRange = `${String(startHour).padStart(2, '0')}:00 ~ ${String(startHour + 1).padStart(2, '0')}:00`;
+
+        if (!acc[timeRange]) {
+          acc[timeRange] = [];
+        }
+        acc[timeRange].push(lecture);
+        return acc;
+      },
+      {} as Record<string, LectureListProps[]>,
+    );
+  };
+
+  const groupedLectures = groupByTime(lectures);
+
+  const sortedTime = Object.keys(groupedLectures).sort((a, b) => {
+    const getHour = (timeRange: string) => parseInt(timeRange.split(':')[0], 10);
+    return getHour(a) - getHour(b);
+  });
+
   return (
-    <div className="pt-10">
-      <h1>강의 목록</h1>
-      <ul>
-        {lectures.map((lecture) => (
-          <li
-            key={lecture.id}
-            className="cursor-pointer hover:bg-gray-100"
-            onClick={() => router.push(`/lecture/${lecture.id}`)}
-          >
-            <strong>{lecture.title}</strong> ({lecture.category})<br />
-            {lecture.start_time} ~ {lecture.end_time} <br />
-            장소: {lecture.location}
-          </li>
+    <div className="p-10">
+      <h1 className="text-2xl font-bold mb-6">{lectures.length} Sessions</h1>
+      <div className="space-y-8">
+        {sortedTime.map((time) => (
+          <div key={time}>
+            <h2 className="text-xl font-semibold mb-4">{time}</h2>
+            <ul className="flex flex-wrap gap-4">
+              {groupedLectures[time].map((lecture) => (
+                <Card
+                  key={lecture.id}
+                  id={lecture.id}
+                  image={lecture.image}
+                  title={lecture.title}
+                  category={lecture.category}
+                  showWish={true}
+                >
+                  <div className="flex items-center mt-1">
+                    <div className="w-4 h-4 bg-gray-300 rounded-full mr-2"></div>
+                    <p className="text-sm font-semibold">{lecture.speakerName}</p>
+                  </div>
+                  <button
+                    className="w-full mt-2 bg-gray-700 text-white py-2 text-sm"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    강의 신청하기
+                  </button>
+                </Card>
+              ))}
+            </ul>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -32,7 +32,11 @@ const LectureListPage = () => {
     // };
 
     // fetchLectures();
-    setLectures(response.data.lectures);
+    if (response && response.data && Array.isArray(response.data.lectures)) {
+      setLectures(response.data.lectures);
+    } else {
+      console.error('데이터 구조가 예상과 다릅니다:', response);
+    }
   }, []);
 
   const groupByTime = (lectures: LectureListProps[]) => {

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+interface CardProps {
+  id: number;
+  image: string;
+  title: string;
+  category: string;
+  children: React.ReactNode;
+  time?: string;
+  showWish?: boolean;
+}
+
+const Card = ({ id, image, title, category, children, time, showWish = true }: CardProps) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(`/lecture/${id}`);
+  };
+
+  return (
+    <div className="overflow-hidden w-60 cursor-pointer" onClick={handleClick}>
+      <div className="relative">
+        <img src={image} alt={title} className="w-full h-36 object-cover" />
+        {showWish && (
+          <button
+            className="absolute top-2 right-2 bg-gray-700 text-white text-xs px-2 py-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            즐찾
+          </button>
+        )}
+      </div>
+      <div className="p-4 border">
+        {time && <div className="w-full bg-white text-xs text-black py-1 rounded">{time}</div>}
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <div className="flex flex-wrap gap-1">
+          <span className="text-xs text-gray-500">#{category}</span>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Card;

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 interface CardProps {
   id: number;
@@ -22,7 +23,14 @@ const Card = ({ id, image, title, category, children, time, showWish = true }: C
   return (
     <div className="overflow-hidden w-60 cursor-pointer" onClick={handleClick}>
       <div className="relative">
-        <img src={image} alt={title} className="w-full h-36 object-cover" />
+        <Image
+          src={image}
+          alt={title}
+          width={300}
+          height={200}
+          className="w-full h-36 object-cover"
+          priority
+        />
         {showWish && (
           <button
             className="absolute top-2 right-2 bg-gray-700 text-white text-xs px-2 py-1"

--- a/src/app/_error.tsx
+++ b/src/app/_error.tsx
@@ -1,0 +1,7 @@
+import { NextPage } from 'next';
+
+const ErrorPage: NextPage = () => {
+  return <div>Something went wrong. Please try again later.</div>;
+};
+
+export default ErrorPage;

--- a/src/app/dummyData/lecture-list/getLectureList.json
+++ b/src/app/dummyData/lecture-list/getLectureList.json
@@ -6,32 +6,36 @@
         "title": "강의 제목1",
         "category": "카테고리1",
         "start_time": "2025-03-04T10:00:00",
-        "end_time": "2025-03-04T12:00:00",
-        "location": "101호"
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
       {
         "id": 2,
         "title": "강의 제목2",
         "category": "카테고리2",
-        "start_time": "2025-03-05T14:00:00",
-        "end_time": "2025-03-05T16:00:00",
-        "location": "202호"
+        "start_time": "2025-03-05T09:00:00",
+        "end_time": "2025-03-05T10:00:00",
+        "speakerName": "고길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
       {
         "id": 3,
         "title": "강의 제목3",
         "category": "카테고리3",
         "start_time": "2025-03-06T09:00:00",
-        "end_time": "2025-03-06T11:00:00",
-        "location": "303"
+        "end_time": "2025-03-06T10:00:00",
+        "speakerName": "김길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
       {
         "id": 4,
         "title": "강의 제목4",
         "category": "카테고리1",
-        "start_time": "2025-03-04T14:00:00",
-        "end_time": "2025-03-04T16:00:00",
-        "location": "101호"
+        "start_time": "2025-03-04T10:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "이길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
       {
         "id": 5,
@@ -39,15 +43,17 @@
         "category": "카테고리2",
         "start_time": "2025-03-05T11:00:00",
         "end_time": "2025-03-05T12:00:00",
-        "location": "202호"
+        "speakerName": "박길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
       {
         "id": 6,
         "title": "강의 제목6",
         "category": "카테고리1",
-        "start_time": "2025-03-06T13:00:00",
-        "end_time": "2025-03-06T14:00:00",
-        "location": "303"
+        "start_time": "2025-03-06T11:00:00",
+        "end_time": "2025-03-06T12:00:00",
+        "speakerName": "최길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       }
     ]
   }


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/card-component` → `dev`

<br/>

## ✅ 작업 내용
- 강의 목록, 메인 페이지, 강사 프로필 페이지에 공통으로 사용되는 카드 컴포넌트 구현
- 세 페이지 모두 공통으로 들어가는 요소인 이미지, 제목, 카테고리는 컴포넌트로 구현
- 시간과 즐겨찾기 버튼의 유무는 선택적으로 전달할 수 있도록 옵션으로 구현
- 강연자와 신청 버튼은 children으로 전달하여 유연하게 추가할 수 있도록 구현

<br/>

## 🌠 이미지 첨부

| 강의 목록 | 메인 | 강사 프로필|
|---|---|---|
| ![스크린샷 2025-03-10 오후 8 26 22](https://github.com/user-attachments/assets/31878d17-53d7-4499-a3c0-9c8cdc63015e) | ![스크린샷 2025-03-10 오후 8 28 37](https://github.com/user-attachments/assets/b3bd868c-b195-4a18-942e-27a3fba88b92) | ![스크린샷 2025-03-10 오후 8 28 55](https://github.com/user-attachments/assets/f9d5da2d-b70a-4e43-ad62-d7f3b1b62c43) |


<br/>

## ✏️ 앞으로의 과제

- 강의 목록 구현

<br/>

## 📌 이슈 링크

- [`feat/card-component` #14 
