### PR TITLE
feat(lecture-list): 강의 목록 구현

### DIFF
--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -44,12 +44,12 @@ const LectureListPage = () => {
       (acc, lecture) => {
         const date = new Date(lecture.start_time);
         const startHour = date.getHours();
-        const timeRange = `${String(startHour).padStart(2, '0')}:00 ~ ${String(startHour + 1).padStart(2, '0')}:00`;
+        const timeStart = `${String(startHour).padStart(2, '0')}:00`;
 
-        if (!acc[timeRange]) {
-          acc[timeRange] = [];
+        if (!acc[timeStart]) {
+          acc[timeStart] = [];
         }
-        acc[timeRange].push(lecture);
+        acc[timeStart].push(lecture);
         return acc;
       },
       {} as Record<string, LectureListProps[]>,
@@ -62,6 +62,13 @@ const LectureListPage = () => {
     const getHour = (timeRange: string) => parseInt(timeRange.split(':')[0], 10);
     return getHour(a) - getHour(b);
   });
+
+  function formatTime(time: string): string {
+    const date = new Date(time);
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
 
   return (
     <div className="p-10">
@@ -78,6 +85,7 @@ const LectureListPage = () => {
                   image={lecture.image}
                   title={lecture.title}
                   category={lecture.category}
+                  time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
                   showWish={true}
                 >
                   <div className="flex items-center mt-1">

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState } from 'react';
 import response from '@/dummyData/lecture-list/getLectureList.json';
 import Card from '@/_components/Card/Card';
+import DayTab from '@/_components/DayTab/DayTab';
+import { groupByDay, groupByTime } from '@/_components/DayTab/groupBy';
 
-interface LectureListProps {
+export interface LectureListProps {
   id: number;
   title: string;
   category: string;
@@ -16,6 +18,7 @@ interface LectureListProps {
 
 const LectureListPage = () => {
   const [lectures, setLectures] = useState<LectureListProps[]>([]);
+  const [selectedDay, setSelectedDay] = useState<string>('Day1');
 
   useEffect(() => {
     // const fetchLectures = async () => {
@@ -39,26 +42,11 @@ const LectureListPage = () => {
     }
   }, []);
 
-  const groupByTime = (lectures: LectureListProps[]) => {
-    return lectures.reduce(
-      (acc, lecture) => {
-        const date = new Date(lecture.start_time);
-        const startHour = date.getHours();
-        const timeStart = `${String(startHour).padStart(2, '0')}:00`;
+  const groupedByDay = groupByDay(lectures);
+  const days = Object.keys(groupedByDay);
+  const groupedByTime = selectedDay ? groupByTime(groupedByDay[selectedDay] || []) : {};
 
-        if (!acc[timeStart]) {
-          acc[timeStart] = [];
-        }
-        acc[timeStart].push(lecture);
-        return acc;
-      },
-      {} as Record<string, LectureListProps[]>,
-    );
-  };
-
-  const groupedLectures = groupByTime(lectures);
-
-  const sortedTime = Object.keys(groupedLectures).sort((a, b) => {
+  const sortedTime = Object.keys(groupedByTime).sort((a, b) => {
     const getHour = (timeRange: string) => parseInt(timeRange.split(':')[0], 10);
     return getHour(a) - getHour(b);
   });
@@ -72,13 +60,14 @@ const LectureListPage = () => {
 
   return (
     <div className="p-10">
+      <DayTab days={days} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
       <h1 className="text-2xl font-bold mb-6">{lectures.length} Sessions</h1>
       <div className="space-y-8">
         {sortedTime.map((time) => (
           <div key={time}>
             <h2 className="text-xl font-semibold mb-4">{time}</h2>
             <ul className="flex flex-wrap gap-4">
-              {groupedLectures[time].map((lecture) => (
+              {groupedByTime[time].map((lecture) => (
                 <Card
                   key={lecture.id}
                   id={lecture.id}

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -9,7 +9,7 @@ interface CardProps {
   title: string;
   category: string;
   children: React.ReactNode;
-  time?: string;
+  time: string;
   showWish?: boolean;
 }
 
@@ -41,7 +41,7 @@ const Card = ({ id, image, title, category, children, time, showWish = true }: C
         )}
       </div>
       <div className="p-4 border">
-        {time && <div className="w-full bg-white text-xs text-black py-1 rounded">{time}</div>}
+        <div className="w-full bg-white text-xs text-black py-1 rounded">{time}</div>
         <h3 className="text-lg font-semibold">{title}</h3>
         <div className="flex flex-wrap gap-1">
           <span className="text-xs text-gray-500">#{category}</span>

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -41,7 +41,9 @@ const Card = ({ id, image, title, category, children, time, showWish = true }: C
         )}
       </div>
       <div className="p-4 border">
-        <div className="w-full bg-white text-xs text-black py-1 rounded">{time}</div>
+        <div className="w-full bg-white text-xs text-black py-1 rounded dark:bg-black dark:text-white">
+          {time}
+        </div>
         <h3 className="text-lg font-semibold">{title}</h3>
         <div className="flex flex-wrap gap-1">
           <span className="text-xs text-gray-500">#{category}</span>

--- a/src/app/_components/DayTab/DayTab.tsx
+++ b/src/app/_components/DayTab/DayTab.tsx
@@ -1,0 +1,23 @@
+interface DayTabProps {
+  days: string[];
+  selectedDay: string;
+  onSelectDay: (day: string) => void;
+}
+
+const DayTab = ({ days, selectedDay, onSelectDay }: DayTabProps) => {
+  return (
+    <div className="flex justify-between border-b-1 mt-2 mb-4 ">
+      {days.map((day) => (
+        <button
+          key={day}
+          className={`text-center w-full py-1 ${selectedDay === day ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+          onClick={() => onSelectDay(day)}
+        >
+          {day}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default DayTab;

--- a/src/app/_components/DayTab/groupBy.ts
+++ b/src/app/_components/DayTab/groupBy.ts
@@ -1,0 +1,34 @@
+import { LectureListProps } from '@/(route)/lecture-list/page';
+
+export const groupByDay = (lectures: LectureListProps[]) => {
+  const grouped: Record<string, LectureListProps[]> = {};
+
+  const sortedLectures = [...lectures].sort(
+    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
+  );
+
+  const uniqueDays = Array.from(
+    new Set(sortedLectures.map((lecture) => new Date(lecture.start_time).toDateString())),
+  );
+
+  uniqueDays.forEach((day, index) => {
+    grouped[`Day${index + 1}`] = sortedLectures.filter(
+      (lecture) => new Date(lecture.start_time).toDateString() === day,
+    );
+  });
+
+  return grouped;
+};
+
+export const groupByTime = (lectures: LectureListProps[]) => {
+  return lectures.reduce(
+    (acc, lecture) => {
+      const timeStart = new Date(lecture.start_time).getHours().toString().padStart(2, '0') + ':00';
+
+      if (!acc[timeStart]) acc[timeStart] = [];
+      acc[timeStart].push(lecture);
+      return acc;
+    },
+    {} as Record<string, LectureListProps[]>,
+  );
+};

--- a/src/app/_error.tsx
+++ b/src/app/_error.tsx
@@ -1,7 +1,0 @@
-import { NextPage } from 'next';
-
-const ErrorPage: NextPage = () => {
-  return <div>Something went wrong. Please try again later.</div>;
-};
-
-export default ErrorPage;

--- a/src/app/dummyData/lecture-list/getLectureList.json
+++ b/src/app/dummyData/lecture-list/getLectureList.json
@@ -14,8 +14,8 @@
         "id": 2,
         "title": "강의 제목2",
         "category": "카테고리2",
-        "start_time": "2025-03-05T09:00:00",
-        "end_time": "2025-03-05T10:00:00",
+        "start_time": "2025-03-05T10:00:00",
+        "end_time": "2025-03-05T12:00:00",
         "speakerName": "고길동",
         "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       },
@@ -32,7 +32,7 @@
         "id": 4,
         "title": "강의 제목4",
         "category": "카테고리1",
-        "start_time": "2025-03-04T10:00:00",
+        "start_time": "2025-03-04T09:00:00",
         "end_time": "2025-03-04T11:00:00",
         "speakerName": "이길동",
         "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
@@ -51,7 +51,7 @@
         "title": "강의 제목6",
         "category": "카테고리1",
         "start_time": "2025-03-06T11:00:00",
-        "end_time": "2025-03-06T12:00:00",
+        "end_time": "2025-03-06T13:00:00",
         "speakerName": "최길동",
         "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+const ErrorPage = ({ error, reset }: { error: Error; reset: () => void }) => {
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,9 @@
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+};
+
+export default RootLayout;


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/lecture-list` → `dev`

<br/>

## ✅ 작업 내용
- 와이어프레임을 기반으로 강의 목록 레이아웃 구현
- 강의 목록과 시간표 페이지에 공통으로 사용되는 DayTab 컴포넌트 구현
- 날짜별 강의 목록 필터링 구현
- 카테고리별 강의 목록 필터링 구현
- 시간대별 강의 목록 필터링 구현
- 다크 모드 적용

<br/>

## 🌠 이미지 첨부

| 날짜별, 시간대별  | 카테고리별  |
|---|---|
| <img width="754" alt="스크린샷 2025-03-11 오후 6 12 56" src="https://github.com/user-attachments/assets/790d479a-3746-40d7-879c-74fc29cb17a1" /> |  <img width="754" alt="스크린샷 2025-03-11 오후 6 13 15" src="https://github.com/user-attachments/assets/09302e87-d7da-4a82-a0b4-434d8ddd0299" /> |


<br/>

## ✏️ 앞으로의 과제

- 시간표 레이아웃 변경

<br/>

## 📌 이슈 링크

- [`feat/lecture-list`] #21 
