### PR TITLE
design(timetable): 시간표 레이아웃 변경

### DIFF
--- a/src/app/_components/DayTab/DayTab.tsx
+++ b/src/app/_components/DayTab/DayTab.tsx
@@ -10,7 +10,7 @@ const DayTab = ({ days, selectedDay, onSelectDay }: DayTabProps) => {
       {days.map((day) => (
         <button
           key={day}
-          className={`text-center w-full py-1 ${selectedDay === day ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+          className={`text-center w-full py-1 cursor-pointer ${selectedDay === day ? 'bg-gray-200 dark:bg-gray-700' : ''} hover:bg-gray-100`}
           onClick={() => onSelectDay(day)}
         >
           {day}


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/timetable` → `dev`

<br/>

## ✅ 작업 내용

- 변경된 시간표 와이어프레임 반영
- 기존에 Day1, Day2, Day3이 각 열에 있는 표 형태에서, 각 날짜를 선택하면 해당 날짜의 시간표만 조회하는 형태로 변경
- DayTab 컴포넌트 활용

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| <img width="750" alt="스크린샷 2025-03-12 오후 7 34 32" src="https://github.com/user-attachments/assets/df70c017-940b-4ce9-8942-46e4e9b8aa83" /> | <img width="752" alt="스크린샷 2025-03-12 오후 7 34 15" src="https://github.com/user-attachments/assets/9769b838-d3d5-43bc-94aa-f4ee1a63415a" /> |


<br/>

## ✏️ 앞으로의 과제

- 즐겨찾기 목록 추가

<br/>

## 📌 이슈 링크

- [`feat/lecture-list`] #26 
