### PR TITLE
fix(font-contentEdit): 폰트 굵기 적용되지 않던 문제 해결

### DIFF
--- a/src/app/_styles/globals.css
+++ b/src/app/_styles/globals.css
@@ -1,3 +1,4 @@
+@import './fonts.css';
 @import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/font-contentEdit` → `dev`

<br/>

## ✅ 작업 내용

- 글꼴 적용 안되던 오류 해결

<br/>

## 🌠 이미지 첨부

<img width="99" alt="image" src="https://github.com/user-attachments/assets/7fa4a8ca-d7b8-4403-8e55-e504e83a1c5b" />

<br/>

## ✏️ 앞으로의 과제

- 헤더 스타일 수정

<br/>

## 📌 이슈 링크

- [`fix/font-contentEdit` #38]
