### PR TITLE
feat(wishlist): 즐겨찾기 목록 추가

### DIFF
--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, Fragment } from 'react';
 import { useRouter } from 'next/navigation';
 import response from '@/dummyData/timetable/getTimetable.json';
+import wishlistResponse from '@/dummyData/timetable/getWishlist.json';
 import recommandLecturesDummy from '@/dummyData/timetable/getTimetableRecommand.json';
 import DayTab from '@/_components/DayTab/DayTab';
 
@@ -33,12 +34,23 @@ interface RecommandLectureProps {
   speaker: string;
 }
 
+interface WishLectureProps {
+  id: number;
+  lectureTitle: string;
+  startTime: string;
+  endTime: string;
+  speaker: string;
+  location: string;
+}
+
 const TimetablePage = () => {
   const [userLectures, setUserLectures] = useState<UserLectures>({ reservation: [], wishlist: [] });
   const [selectedDay, setSelectedDay] = useState<string>('Day1');
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
   const [recommandLectures, setRecommandLectures] = useState<RecommandLectureProps[]>([]);
   const [baseDate, setBaseDate] = useState<Date | null>(null);
+  const [wishlist, setWishlist] = useState<WishLectureProps[]>([]);
+  const [showWishlist, setShowWishlist] = useState<boolean>(false);
 
   const router = useRouter();
   const currentUserId = 222; // 현재 로그인한 유저 ID 가져오는 로직 추가
@@ -116,6 +128,7 @@ const TimetablePage = () => {
   const handleEmptySlotClick = (day: number, start: string) => {
     if (!baseDate) return;
 
+    setShowWishlist(false);
     setSelectedTime(`Day${day} ${start}`);
 
     const selectedDate = new Date(baseDate);
@@ -142,16 +155,21 @@ const TimetablePage = () => {
 
   const occupiedSlots = new Set();
 
+  const handleWishlistClick = () => {
+    setWishlist(wishlistResponse.response);
+    setSelectedTime(null);
+    setShowWishlist((prev) => !prev);
+  };
+
   return (
     <div className="flex gap-4">
       <div className="flex-2 p-10">
-        <h1
-          className={`text-xl font-bold mb-4 transition-all ${
-            selectedTime ? 'text-left' : 'text-center w-full'
-          }`}
-        >
-          컴퍼런스 일정 시간표
-        </h1>
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-bold transition-all">컴퍼런스 일정 시간표</h1>
+          <button className="bg-gray-200 px-1 cursor-pointer" onClick={handleWishlistClick}>
+            즐찾
+          </button>
+        </div>
         <DayTab
           days={['Day1', 'Day2', 'Day3']}
           selectedDay={selectedDay}
@@ -298,6 +316,45 @@ const TimetablePage = () => {
                     </span>
                   </div>
                   <span>{lecture?.title}</span>
+                  <div className="flex justify-between w-full">
+                    <p>{lecture.speaker}</p>
+                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                      강의 신청
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {showWishlist && (
+        <div className="flex-1 p-4 pt-10 bg-gray-50 h-screen dark:bg-gray-900">
+          <h3 className="text-md font-semibold">즐겨찾기 목록</h3>
+          <div className="h-full overflow-auto">
+            <ul className="mt-2 border">
+              {wishlist.map((lecture) => (
+                <li key={lecture.id} className="p-2 border-b border-gray-200">
+                  <div className="flex items-center gap-2">
+                    <p className="bg-gray-200 text-sm w-fit px-2 dark:bg-gray-600">
+                      {lecture.location}
+                    </p>
+                    <span className="text-xs">
+                      {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}{' '}
+                      -{' '}
+                      {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                      })}
+                    </span>
+                  </div>
+                  <span>{lecture?.lectureTitle}</span>
                   <div className="flex justify-between w-full">
                     <p>{lecture.speaker}</p>
                     <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -162,211 +162,213 @@ const TimetablePage = () => {
   };
 
   return (
-    <div className="flex gap-4">
-      <div className="flex-2 p-10">
-        <div className="flex justify-between items-center mb-4">
-          <h1 className="text-xl font-bold transition-all">컴퍼런스 일정 시간표</h1>
-          <button className="bg-gray-200 px-1 cursor-pointer" onClick={handleWishlistClick}>
-            즐찾
-          </button>
-        </div>
-        <DayTab
-          days={['Day1', 'Day2', 'Day3']}
-          selectedDay={selectedDay}
-          onSelectDay={setSelectedDay}
-        />
-
-        <div className="grid border border-gray-300" style={{ gridTemplateColumns: '140px 1fr' }}>
-          {timeSlots.map(({ start, end }) => {
-            if (occupiedSlots.has(start)) {
-              return (
-                <div
-                  key={`empty-${start}`}
-                  className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium"
-                >
-                  {start} ~ {end}
-                </div>
-              );
-            }
-
-            const lecture = filteredLectures.find(
-              (lecture) =>
-                new Date(lecture.start_time).toLocaleTimeString('ko-KR', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: false,
-                }) === start,
-            );
-
-            const rowSpan = lecture
-              ? (new Date(lecture.end_time).getTime() - new Date(lecture.start_time).getTime()) /
-                (60 * 60 * 1000)
-              : 1;
-
-            if (lecture) {
-              const occupiedTime = new Date(lecture.start_time);
-              for (let i = 0; i < rowSpan; i++) {
-                const timeKey = occupiedTime.toLocaleTimeString('ko-KR', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: false,
-                });
-                occupiedSlots.add(timeKey);
-                occupiedTime.setHours(occupiedTime.getHours() + 1);
-              }
-            }
-
-            return (
-              <Fragment key={`time-${start}-${end}`}>
-                <div className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium">
-                  {start} ~ {end}
-                </div>
-
-                {lecture ? (
-                  <div
-                    key={lecture.id}
-                    className="p-4 text-left cursor-pointer"
-                    style={{
-                      gridRow: `span ${rowSpan}`,
-                      backgroundColor: '#fff',
-                      border: '1px solid #ccc',
-                      borderBottom: rowSpan > 1 ? 'none' : '1px solid #ccc',
-                    }}
-                    onClick={() => router.push(`/lecture/${lecture.lecture_id}`)}
-                  >
-                    <p className="w-fit bg-gray-200 px-1">{lecture.location}</p>
-                    <p>{lecture.title}</p>
-                    <div className="flex justify-between">
-                      <p>{lecture.speaker}</p>
-                      <p>
-                        인원수 {lecture.count} / {lecture.total}
-                      </p>
-                    </div>
-                  </div>
-                ) : (
-                  <div
-                    className="border border-gray-300 bg-gray-50 hover:bg-gray-200 cursor-pointer"
-                    style={{
-                      gridRow: 'span 1',
-                    }}
-                    onClick={() =>
-                      handleEmptySlotClick(Number(selectedDay.replace('Day', '')), start)
-                    }
-                  />
-                )}
-              </Fragment>
-            );
-          })}
-        </div>
+    <div className="p-10">
+      <div className="w-full flex justify-between items-center py-4">
+        <h1 className="text-xl font-bold">컴퍼런스 일정 시간표</h1>
+        <button className="bg-gray-200 px-1 cursor-pointer" onClick={handleWishlistClick}>
+          즐찾
+        </button>
       </div>
+      <div className="flex gap-2 w-full">
+        <div className="flex-2">
+          <DayTab
+            days={['Day1', 'Day2', 'Day3']}
+            selectedDay={selectedDay}
+            onSelectDay={setSelectedDay}
+          />
 
-      {selectedTime && (
-        <div className="flex-1 p-4 pt-10 bg-gray-50 h-screen dark:bg-gray-900">
-          <h3 className=" text-md font-semibold">즐찾 목록</h3>
-          <div className="h-1/3 overflow-auto">
-            <ul className="mt-2 border">
-              {userLectures.wishlist.map((lecture) => (
-                <li key={lecture.id} className="p-2 border-b border-gray-200">
-                  <div className="flex items-center gap-2">
-                    <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
-                    <span className="text-xs">
-                      {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}{' '}
-                      -{' '}
-                      {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}
-                    </span>
+          <div className="grid border border-gray-300" style={{ gridTemplateColumns: '140px 1fr' }}>
+            {timeSlots.map(({ start, end }) => {
+              if (occupiedSlots.has(start)) {
+                return (
+                  <div
+                    key={`empty-${start}`}
+                    className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium"
+                  >
+                    {start} ~ {end}
                   </div>
-                  <span>{lecture?.title}</span>
-                  <div className="flex justify-between w-full">
-                    <p>{lecture.speaker}</p>
-                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
-                      강의 신청
-                    </button>
+                );
+              }
+
+              const lecture = filteredLectures.find(
+                (lecture) =>
+                  new Date(lecture.start_time).toLocaleTimeString('ko-KR', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: false,
+                  }) === start,
+              );
+
+              const rowSpan = lecture
+                ? (new Date(lecture.end_time).getTime() - new Date(lecture.start_time).getTime()) /
+                  (60 * 60 * 1000)
+                : 1;
+
+              if (lecture) {
+                const occupiedTime = new Date(lecture.start_time);
+                for (let i = 0; i < rowSpan; i++) {
+                  const timeKey = occupiedTime.toLocaleTimeString('ko-KR', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: false,
+                  });
+                  occupiedSlots.add(timeKey);
+                  occupiedTime.setHours(occupiedTime.getHours() + 1);
+                }
+              }
+
+              return (
+                <Fragment key={`time-${start}-${end}`}>
+                  <div className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium">
+                    {start} ~ {end}
                   </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <h3 className="pt-10 text-md font-semibold">공석 추천 목록</h3>
-          <div className="h-1/2 overflow-auto">
-            <ul className="mt-2 border">
-              {recommandLectures.map((lecture) => (
-                <li key={lecture.lecture_id} className="p-2 border-b border-gray-200">
-                  <div className="flex items-center gap-2">
-                    <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
-                    <span className="text-xs">
-                      {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}{' '}
-                      -{' '}
-                      {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}
-                    </span>
-                  </div>
-                  <span>{lecture?.title}</span>
-                  <div className="flex justify-between w-full">
-                    <p>{lecture.speaker}</p>
-                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
-                      강의 신청
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
+
+                  {lecture ? (
+                    <div
+                      key={lecture.id}
+                      className="p-4 text-left cursor-pointer"
+                      style={{
+                        gridRow: `span ${rowSpan}`,
+                        backgroundColor: '#fff',
+                        border: '1px solid #ccc',
+                        borderBottom: rowSpan > 1 ? 'none' : '1px solid #ccc',
+                      }}
+                      onClick={() => router.push(`/lecture/${lecture.lecture_id}`)}
+                    >
+                      <p className="w-fit bg-gray-200 px-1">{lecture.location}</p>
+                      <p>{lecture.title}</p>
+                      <div className="flex justify-between">
+                        <p>{lecture.speaker}</p>
+                        <p>
+                          인원수 {lecture.count} / {lecture.total}
+                        </p>
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      className="border border-gray-300 bg-gray-50 hover:bg-gray-200 cursor-pointer"
+                      style={{
+                        gridRow: 'span 1',
+                      }}
+                      onClick={() =>
+                        handleEmptySlotClick(Number(selectedDay.replace('Day', '')), start)
+                      }
+                    />
+                  )}
+                </Fragment>
+              );
+            })}
           </div>
         </div>
-      )}
 
-      {showWishlist && (
-        <div className="flex-1 p-4 pt-10 bg-gray-50 h-screen dark:bg-gray-900">
-          <h3 className="text-md font-semibold">즐겨찾기 목록</h3>
-          <div className="h-full overflow-auto">
-            <ul className="mt-2 border">
-              {wishlist.map((lecture) => (
-                <li key={lecture.id} className="p-2 border-b border-gray-200">
-                  <div className="flex items-center gap-2">
-                    <p className="bg-gray-200 text-sm w-fit px-2 dark:bg-gray-600">
-                      {lecture.location}
-                    </p>
-                    <span className="text-xs">
-                      {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}{' '}
-                      -{' '}
-                      {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}
-                    </span>
-                  </div>
-                  <span>{lecture?.lectureTitle}</span>
-                  <div className="flex justify-between w-full">
-                    <p>{lecture.speaker}</p>
-                    <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
-                      강의 신청
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
+        {selectedTime && (
+          <div className="flex-1 p-4 bg-gray-50 h-screen dark:bg-gray-900">
+            <h3 className=" text-md font-semibold">즐찾 목록</h3>
+            <div className="h-1/3 overflow-auto">
+              <ul className="mt-2 border">
+                {userLectures.wishlist.map((lecture) => (
+                  <li key={lecture.id} className="p-2 border-b border-gray-200">
+                    <div className="flex items-center gap-2">
+                      <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
+                      <span className="text-xs">
+                        {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}{' '}
+                        -{' '}
+                        {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}
+                      </span>
+                    </div>
+                    <span>{lecture?.title}</span>
+                    <div className="flex justify-between w-full">
+                      <p>{lecture.speaker}</p>
+                      <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                        강의 신청
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <h3 className="pt-10 text-md font-semibold">공석 추천 목록</h3>
+            <div className="h-1/2 overflow-auto">
+              <ul className="mt-2 border">
+                {recommandLectures.map((lecture) => (
+                  <li key={lecture.lecture_id} className="p-2 border-b border-gray-200">
+                    <div className="flex items-center gap-2">
+                      <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
+                      <span className="text-xs">
+                        {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}{' '}
+                        -{' '}
+                        {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}
+                      </span>
+                    </div>
+                    <span>{lecture?.title}</span>
+                    <div className="flex justify-between w-full">
+                      <p>{lecture.speaker}</p>
+                      <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                        강의 신청
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+
+        {showWishlist && (
+          <div className="flex-1 p-4 bg-gray-50 h-screen dark:bg-gray-900">
+            <h3 className="text-md font-semibold">즐겨찾기 목록</h3>
+            <div className="h-full overflow-auto">
+              <ul className="mt-2 border">
+                {wishlist.map((lecture) => (
+                  <li key={lecture.id} className="p-2 border-b border-gray-200">
+                    <div className="flex items-center gap-2">
+                      <p className="bg-gray-200 text-sm w-fit px-2 dark:bg-gray-600">
+                        {lecture.location}
+                      </p>
+                      <span className="text-xs">
+                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}{' '}
+                        -{' '}
+                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          hour12: false,
+                        })}
+                      </span>
+                    </div>
+                    <span>{lecture?.lectureTitle}</span>
+                    <div className="flex justify-between w-full">
+                      <p>{lecture.speaker}</p>
+                      <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                        강의 신청
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/app/_components/DayTab/DayTab.tsx
+++ b/src/app/_components/DayTab/DayTab.tsx
@@ -6,7 +6,7 @@ interface DayTabProps {
 
 const DayTab = ({ days, selectedDay, onSelectDay }: DayTabProps) => {
   return (
-    <div className="flex justify-between border-b-1 mt-2 mb-4 ">
+    <div className="flex justify-between border-b-1 mb-4 ">
       {days.map((day) => (
         <button
           key={day}

--- a/src/app/dummyData/timetable/getWishlist.json
+++ b/src/app/dummyData/timetable/getWishlist.json
@@ -1,0 +1,36 @@
+{
+  "response": [
+    {
+      "id": 1,
+      "speaker": "황효주",
+      "lectureTitle": "즐찾제목1",
+      "startTime": "2025-03-04T10:00:00",
+      "endTime": "2025-03-04T12:00:00",
+      "location": "Room A-1"
+    },
+    {
+      "id": 2,
+      "speaker": "황효주",
+      "lectureTitle": "즐찾제목2",
+      "startTime": "2025-03-04T14:00:00",
+      "endTime": "2025-03-04T15:00:00",
+      "location": "Room A-2"
+    },
+    {
+      "id": 3,
+      "speaker": "황효주",
+      "lectureTitle": "즐찾제목3",
+      "startTime": "2025-03-05T10:00:00",
+      "endTime": "2025-03-05T12:00:00",
+      "location": "Room A-3"
+    },
+    {
+      "id": 4,
+      "speaker": "황효주",
+      "lectureTitle": "즐찾제목4",
+      "startTime": "2025-03-06T10:00:00",
+      "endTime": "2025-03-06T12:00:00",
+      "location": "Room A-4"
+    }
+  ]
+}


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/wishlist` → `dev`

<br/>

## ✅ 작업 내용

- 시간표 페이지에 즐겨찾기 목록 버튼 추가
- 사용자가 즐겨찾기한 모든 강의 목록을 보여줌
- 오른쪽에 목록이 나타날 때, 헤더부분은 상단 고정되도록 레이아웃 수정

<br/>

## 🌠 이미지 첨부

<img width="779" alt="스크린샷 2025-03-13 오후 3 45 48" src="https://github.com/user-attachments/assets/93988287-264c-43b8-aae7-dcfc76c7e22a" />

<br/>

## ✏️ 앞으로의 과제

- 즐겨찾기 기능 구현

<br/>

## 📌 이슈 링크

- [`feat/lwishlist`] resolve #33 
