### PR TITLE
Chore(eslint): 웹 접근성 규칙 추가

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ const ignoreConfig = {
 
 const eslintConfig = [
   ignoreConfig,
-  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
+  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier','plugin:jsx-a11y/recommended'),
   {
     plugins: {
       prettier: prettierPlugin,
@@ -42,6 +42,19 @@ const eslintConfig = [
       'array-bracket-newline': 'off',
 
       'prettier/prettier': ['error', prettierConfig],
+
+      'jsx-a11y/click-events-have-key-events': 'warn',  // 클릭 이벤트가 있는 요소에 키보드 이벤트 요구 
+      'jsx-a11y/no-static-element-interactions': 'off',  // span, div 요소에서 이벤트 사용시 오류
+      'jsx-a11y/no-noninteractive-element-interactions': 'off',  // 비대화 요소에서 이벤트 사용시 오류
+      'jsx-a11y/interactive-supports-focus': 'off', // 포커스 지원 요구
+
+      'jsx-a11y/control-has-associated-label': [
+        'warn', 
+        {
+          controlComponents: ['button', 'input'], 
+          ignoreElements: ['textarea'], 
+        },
+      ],
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.2.0",
         "eslint-config-prettier": "^10.0.2",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.2.3",
         "prettier": "^3.5.2",
         "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
     "eslint-config-prettier": "^10.0.2",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.2.3",
     "prettier": "^3.5.2",
     "tailwindcss": "^4",


### PR DESCRIPTION
## 🚀 반영 브랜치

`chore/eslint` → `dev`

<br/>

## ✅ 작업 내용

- 버튼 라벨링 없을시 warn
- 클릭 이벤트가 있는 요소에 키보드 이벤트가 없을 시 warn
- span, div 요소에서 이벤트 사용시 warn
- 비대화 요소(span, div, li, ol 등등)에서 이벤트 사용시 warn

<br/>

## 🌠 이미지 첨부

<img width="773" alt="image" src="https://github.com/user-attachments/assets/3aa2a8b2-0538-45a1-9621-531dd348aed8" />

<br/>

## ✏️ 앞으로의 과제

- 알림 퍼블리싱
- 마이 페이지 퍼블리싱

<br/>

## 📌 이슈 링크

- [chore/eslint #44 ]
