### PR TITLE
design(card component): 카드 컴포넌트 구조 및 디자인 변경

### DIFF
--- a/src/app/(route)/(main)/mainComponent/SecSection.tsx
+++ b/src/app/(route)/(main)/mainComponent/SecSection.tsx
@@ -78,10 +78,9 @@ const SecSection = () => {
                 title={lecture.title}
                 time="임시 시간"
                 category={lecture.category}
-                showWish={true}
-              >
-                <></>
-              </Card>
+                speakerName={lecture.speakerName}
+                isProfile={false}
+              />
             ))}
           </ScrollWrapper>
         </div>

--- a/src/app/(route)/(main)/page.tsx
+++ b/src/app/(route)/(main)/page.tsx
@@ -28,10 +28,6 @@ export default Page;
 //   title={lecture.title}
 //   category={lecture.category}
 //   time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
-//   showWish={true}
-// >
-//   <div className="flex items-center mt-1">
-//     <div className="w-4 h-4 bg-gray-300 rounded-full mr-2"></div>
-//     <p className="text-sm font-semibold">{lecture.speakerName}</p>
-//   </div>
-// </Card>;
+//   speakerName={lecture.speakerName}
+//   isProfile={false}
+// />

--- a/src/app/(route)/instructor/[id]/page.tsx
+++ b/src/app/(route)/instructor/[id]/page.tsx
@@ -101,10 +101,8 @@ const Page = () => {
                   title={lecture.title}
                   time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
                   category={lecture.category}
-                  showWish={true}
-                >
-                  <></>
-                </Card>
+                  isProfile={true}
+                />
               ))}
             </ScrollWrapper>
           </div>

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -153,19 +153,9 @@ const LectureListPage = () => {
                   title={lecture.title}
                   category={lecture.category}
                   time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
-                  showWish={true}
-                >
-                  <div className="flex items-center mt-1">
-                    <div className="w-4 h-4 bg-gray-300 rounded-full mr-2"></div>
-                    <p className="text-sm font-semibold">{lecture.speakerName}</p>
-                  </div>
-                  <button
-                    className="w-full mt-2 bg-gray-700 text-white py-2 text-sm"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    강의 신청하기
-                  </button>
-                </Card>
+                  speakerName={lecture.speakerName}
+                  isProfile={false}
+                />
               ))}
             </ul>
           </div>

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -9,11 +9,11 @@ interface CardProps {
   title: string;
   category: string;
   time: string;
-  speakerName: string;
+  speakerName?: string;
   isProfile?: boolean;
 }
 
-const Card = ({ id, image, title, category, time, speakerName, isProfile }: CardProps) => {
+const Card = ({ id, image, title, category, time, speakerName, isProfile = false }: CardProps) => {
   const router = useRouter();
 
   const handleClick = () => {

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -8,12 +8,12 @@ interface CardProps {
   image: string;
   title: string;
   category: string;
-  children: React.ReactNode;
   time: string;
-  showWish?: boolean;
+  speakerName: string;
+  isProfile?: boolean;
 }
 
-const Card = ({ id, image, title, category, children, time, showWish = true }: CardProps) => {
+const Card = ({ id, image, title, category, time, speakerName, isProfile }: CardProps) => {
   const router = useRouter();
 
   const handleClick = () => {
@@ -21,34 +21,50 @@ const Card = ({ id, image, title, category, children, time, showWish = true }: C
   };
 
   return (
-    <div className="overflow-hidden w-60 cursor-pointer" onClick={handleClick}>
+    <div
+      className="overflow-hidden w-[282px] border border-[#DEE2E6] rounded-xl cursor-pointer"
+      onClick={handleClick}
+    >
       <div className="relative">
         <Image
           src={image}
           alt={title}
-          width={300}
-          height={200}
-          className="w-full h-36 object-cover"
+          width={282}
+          height={170}
+          className="w-full h-[170] object-cover"
           priority
         />
-        {showWish && (
-          <button
-            className="absolute top-2 right-2 bg-gray-700 text-white text-xs px-2 py-1"
-            onClick={(e) => e.stopPropagation()}
-          >
-            즐찾
-          </button>
-        )}
+        <button
+          className="absolute top-4 right-4 bg-gray-200 text-white text-xs px-2 py-1 w-8 h-8"
+          onClick={(e) => e.stopPropagation()}
+        >
+          ⭐️
+        </button>
       </div>
-      <div className="p-4 border">
-        <div className="w-full bg-white text-xs text-black py-1 rounded dark:bg-black dark:text-white">
+      <div className="px-4 py-5">
+        <div className="w-full bg-white text-sm font-semibold leading-[140%] dark:bg-black dark:text-white">
           {time}
         </div>
-        <h3 className="text-lg font-semibold">{title}</h3>
-        <div className="flex flex-wrap gap-1">
-          <span className="text-xs text-gray-500">#{category}</span>
+        <h3 className="text-[20px] font-bold leading-[140%] pt-1">{title}</h3>
+
+        {!isProfile && (
+          <div className="flex items-center pt-1">
+            <p className="text-sm font-semibold leading-[140%] text-[#A09F9F]">{speakerName}</p>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-1 pt-3">
+          <span className="text-sm font-semibold leading-[140%] text-[#878787]">#{category}</span>
         </div>
-        {children}
+
+        {!isProfile && (
+          <button
+            className="w-full text-[16px] font-semibold leading-[140%] bg-[#155DFC] text-white p-3 mt-3 rounded-sm"
+            onClick={(e) => e.stopPropagation()}
+          >
+            강의 신청하기
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/card` → `dev`

<br/>

## ✅ 작업 내용

- Hi-Fi Wireframe을 기반으로 카드 컴포넌트의 디자인 수정
- 카드 컴포넌트가 사용되는 모든 페이지에서 즐겨찾기 버튼이 항상 렌더링되도록 변경 (조건부 렌더링 제거)
- 메인 페이지와 강의 목록 페이지에서 동일한 요소를 렌더링하도록 디자인을 통일하면서 컴포넌트 구조 변경
- spacing(margin, padding, gap) 적용
- style(align, color, radius) 적용
- font(size, weight, line-height) 적용

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| ![image](https://github.com/user-attachments/assets/0085e90a-e9f6-46a1-a9e6-e771fc1c1375) | <img width="290" alt="스크린샷 2025-03-14 오전 10 53 33" src="https://github.com/user-attachments/assets/5e218e13-1c32-4d7b-b8fd-2df64f76fdb6" /> |


<br/>

## ✏️ 앞으로의 과제

- 즐겨찾기 기능 구현

<br/>

## 📌 이슈 링크

- [`design/card`] #43 
