### PR TITLE
design(my-page): 마이페이지 퍼블리싱

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,12 @@ const ignoreConfig = {
 
 const eslintConfig = [
   ignoreConfig,
-  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier','plugin:jsx-a11y/recommended'),
+  ...compat.extends(
+    'next/core-web-vitals',
+    'next/typescript',
+    'prettier',
+    'plugin:jsx-a11y/recommended',
+  ),
   {
     plugins: {
       prettier: prettierPlugin,
@@ -43,16 +48,16 @@ const eslintConfig = [
 
       'prettier/prettier': ['error', prettierConfig],
 
-      'jsx-a11y/click-events-have-key-events': 'warn',  // 클릭 이벤트가 있는 요소에 키보드 이벤트 요구 
-      'jsx-a11y/no-static-element-interactions': 'off',  // span, div 요소에서 이벤트 사용시 오류
-      'jsx-a11y/no-noninteractive-element-interactions': 'off',  // 비대화 요소에서 이벤트 사용시 오류
+      'jsx-a11y/click-events-have-key-events': 'warn', // 클릭 이벤트가 있는 요소에 키보드 이벤트 요구
+      'jsx-a11y/no-static-element-interactions': 'off', // span, div 요소에서 이벤트 사용시 오류
+      'jsx-a11y/no-noninteractive-element-interactions': 'off', // 비대화 요소에서 이벤트 사용시 오류
       'jsx-a11y/interactive-supports-focus': 'off', // 포커스 지원 요구
 
       'jsx-a11y/control-has-associated-label': [
-        'warn', 
+        'warn',
         {
-          controlComponents: ['button', 'input'], 
-          ignoreElements: ['textarea'], 
+          controlComponents: ['button', 'input'],
+          ignoreElements: ['textarea'],
         },
       ],
     },

--- a/src/app/(route)/layout.tsx
+++ b/src/app/(route)/layout.tsx
@@ -15,7 +15,7 @@ const RootLayout = async ({ children }: Readonly<{ children: React.ReactNode }>)
       >
         <KaKaoScript />
         <Header />
-        {children}
+        <div className="pt-[81px]">{children}</div>
       </body>
     </html>
   );

--- a/src/app/(route)/mypage/[id]/page.tsx
+++ b/src/app/(route)/mypage/[id]/page.tsx
@@ -1,10 +1,66 @@
-import { MyPageAsideNavigation } from '@/_components/Nav/navigation/AsideNav';
-
+// 초기값 server -> client(상태 초기값) -> update
 const Page = () => {
   return (
     <div className="flex w-screen">
-      <MyPageAsideNavigation />
+      <div className="max-w-[1280px] px-[40px] h-auto w-full flex flex-col mt-16 mx-auto">
+        {/* 정보 */}
+        <div className="flex gap-6">
+          {/* 이미지 */}
+          <div>
+            <div className="w-[180px] aspect-square bg-black" aria-label="이미지 대체" />
+          </div>
 
+          <div className="flex flex-col gap-4 w-[450px]">
+            {/* 이름 */}
+            <div className="w-[450px] h-[40px] grid grid-cols-[78px_auto] [grid-template-rows:40px] items-center">
+              <span className="font-semibold h-full flex items-center">이름</span>
+              <div
+                id="name"
+                aria-label="id"
+                className="w-[282px] h-full flex items-center border border-solid border-[#D9D9D9] px-3 rounded-[8px]"
+              >
+                김지훈
+              </div>
+            </div>
+
+            {/* 이메일 */}
+            <div className="w-[450px] h-[40px] grid grid-cols-[78px_auto] [grid-template-rows:40px] items-center">
+              <span className="font-semibold h-full flex items-center">이메일</span>
+              <form className="flex mr-1 w-full">
+                <input
+                  aria-label="email"
+                  id="name"
+                  type="text"
+                  placeholder="이메일을 입력해주세요"
+                  className="w-[282px] border border-solid border-[#D9D9D9] px-3 rounded-[8px] mr-3"
+                />
+                <input
+                  aria-label="change-email"
+                  className="btn px-4 py-2 rounded-[8px]"
+                  value="저장"
+                  type="button"
+                />
+              </form>
+            </div>
+          </div>
+        </div>
+        {/* 로그아웃 */}
+        <div className="w-full mt-[40px]">
+          <span className="block">현재 계정에서 로그아웃합니다.</span>
+          <span className="block">다시 로그인하려면 카카오 계정을 사용해 주세요</span>
+          <button className="btn block px-4 py-2 mt-6 rounded-[8px]">로그아웃</button>
+        </div>
+
+        {/* 회원탈퇴 */}
+        <div className="w-full mt-[40px]">
+          <span className="block">1. 회원 탈퇴를 진행하시면 아래 내용이 적용됩니다.</span>
+          <span className="block">2. 서비스 이용 기록 영구 삭제</span>
+          <span className="block">
+            3. 복구가 불가능하며, 동일한 이메일로 재가입이 제한될 수 있음
+          </span>
+          <button className="btn block px-4 py-2 mt-6 rounded-[8px]">로그아웃</button>
+        </div>
+      </div>
       <div />
     </div>
   );

--- a/src/app/_styles/globals.css
+++ b/src/app/_styles/globals.css
@@ -2,6 +2,35 @@
 @import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 
+@layer components {
+  .btn {
+    color:#fff;
+    background-color: var(--color-bg-interactive-primary, #155DFC);
+  }
+
+  .dark .btn {
+    background-color: #333;
+    color:#fff;
+  }
+
+  .bg-primary {
+    background-color: var(--color-bg-interactive-primary, #155DFC);
+  }
+
+  .dark .bg-primary {
+    background-color: #333;
+  }
+
+  .text-primary {
+    color:#fff;
+  }
+
+  .dark .text-primary {
+    background-color: #333;
+  }
+
+}
+
 @theme {
   /* --font-sans: var(--font-geist-sans); */
   /* --font-mono: var(--font-geist-mono); */
@@ -28,3 +57,4 @@ body {
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
 }
+

--- a/src/app/_styles/globals.css
+++ b/src/app/_styles/globals.css
@@ -4,17 +4,17 @@
 
 @layer components {
   .btn {
-    color:#fff;
-    background-color: var(--color-bg-interactive-primary, #155DFC);
+    color: #fff;
+    background-color: var(--color-bg-interactive-primary, #155dfc);
   }
 
   .dark .btn {
     background-color: #333;
-    color:#fff;
+    color: #fff;
   }
 
   .bg-primary {
-    background-color: var(--color-bg-interactive-primary, #155DFC);
+    background-color: var(--color-bg-interactive-primary, #155dfc);
   }
 
   .dark .bg-primary {
@@ -22,13 +22,12 @@
   }
 
   .text-primary {
-    color:#fff;
+    color: #fff;
   }
 
   .dark .text-primary {
     background-color: #333;
   }
-
 }
 
 @theme {
@@ -57,4 +56,3 @@ body {
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
 }
-

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,10 @@ const config: Config = {
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
     extend: {
+      colors: {
+        primary:  "#155DFC", 
+      },
+      
       fontFamily: {
         pretendard: ['Pretendard', 'sans-serif'],
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,9 +6,9 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        primary:  "#155DFC", 
+        primary: '#155DFC',
       },
-      
+
       fontFamily: {
         pretendard: ['Pretendard', 'sans-serif'],
       },


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/my-page` → `dev`

<br/>

## ✅ 작업 내용

- 마이 페이지 초기 구조 퍼블리싱
-  버튼들의 색상이 모두 동일하여 **재사용 가능한 `.btn` 클래스 추가**
    - `.btn` 클래스는 배경색, 글자색만 반영
    - 버튼마다 `padding` 및 `border-radius` 값이 달라 따로 이 부분은 적용하지 않음
    - **다크 모드 자동 반영** 

**예시**
```typescript
return <div class="btn px-2 py-4"/>;
```
<img width="62" alt="image" src="https://github.com/user-attachments/assets/379dff5b-d072-4518-b52d-1945444c6044" />
<img width="61" alt="image" src="https://github.com/user-attachments/assets/0bf0b143-c7e3-43cb-a8ba-6aa60f920277" />


<br/>

## 🌠 이미지 첨부

마이페이지
<img width="971" alt="image" src="https://github.com/user-attachments/assets/80778a8c-db56-45b0-be21-457e007da880" />

<br/>

## ✏️ 앞으로의 과제

- 메인 페이지 퍼블리싱 
- 알림 기능 개발

<br/>

## 📌 이슈 링크

- [`design/my-page` #49]
