### PR TITLE
design(card): 카드 컴포넌트 배경색 추가

### DIFF
--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -33,7 +33,7 @@ const Card = ({
 
   return (
     <div
-      className="overflow-hidden w-[282px] border border-[#DEE2E6] rounded-xl cursor-pointer"
+      className="overflow-hidden w-[282px] bg-white border border-[#DEE2E6] rounded-xl cursor-pointer"
       onClick={handleClick}
     >
       <div className="relative">


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/card` → `dev`

<br/>

## ✅ 작업 내용

- 카드 컴포넌트에 배경색 추가하여 뒤 배경이 비쳐 보이는 문제 해결

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| ![image](https://github.com/user-attachments/assets/0e634b4c-a955-420f-b122-2a4328896693) | <img width="301" alt="스크린샷 2025-03-17 오전 9 27 37" src="https://github.com/user-attachments/assets/e64cf786-3d43-4adf-bb86-08cab82b8fb3" /> |


<br/>

## ✏️ 앞으로의 과제

- 강의 목록 디자인 수정

<br/>

## 📌 이슈 링크

- [`design/card`] #60
