### PR TITLE
design(lecture list): 강의 목록 디자인 수정

### DIFF
--- a/src/app/(route)/layout.tsx
+++ b/src/app/(route)/layout.tsx
@@ -15,7 +15,7 @@ const RootLayout = async ({ children }: Readonly<{ children: React.ReactNode }>)
       >
         <KaKaoScript />
         <Header />
-        <div className="pt-[81px]">{children}</div>
+        <div className="pt-[81px] max-w-7xl mx-auto my-0">{children}</div>
       </body>
     </html>
   );

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -53,7 +53,9 @@ const LectureListPage = () => {
     <div className="px-10 py-16">
       <DayTab days={days} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
       <div className="relative flex justify-between items-center h-10 mt-10">
-        <h1 className="text-lg font-medium leading-[140%]">{lectures.length} Sessions</h1>
+        <h1 className="text-lg font-medium leading-[140%]">
+          {groupedByDay[selectedDay]?.length || 0} Sessions
+        </h1>
         <button
           onClick={() => setIsFilterOpen(true)}
           className="text-lg font-medium leading-[140%] border-1 border-gray-300 rounded-lg dark:bg-neutral-800"

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -5,6 +5,7 @@ import { LectureListProps, useLectureStore } from '@/_store/LectureList/useLectu
 import Card from '@/_components/Card/Card';
 import DayTab from '@/_components/DayTab/DayTab';
 import { groupByDay, groupByTime } from '@/_components/DayTab/groupBy';
+import { HiOutlineAdjustmentsHorizontal } from 'react-icons/hi2';
 
 const LectureListPage = () => {
   const { lecturelist, wishlist, fetchLectures, fetchWishlist } = useLectureStore();
@@ -49,22 +50,22 @@ const LectureListPage = () => {
   const categories = Array.from(new Set(lectures.map((lecture) => lecture.category)));
 
   return (
-    <div className="p-10">
+    <div className="px-10 py-16">
       <DayTab days={days} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
-      <div className="relative flex justify-between">
-        <h1 className="text-2xl font-bold mb-6">{lectures.length} Sessions</h1>
+      <div className="relative flex justify-between items-center h-10 mt-10">
+        <h1 className="text-lg font-medium leading-[140%]">{lectures.length} Sessions</h1>
         <button
           onClick={() => setIsFilterOpen(true)}
-          className="bg-red-300 text-white px-4 py-2 mb-4 dark:bg-neutral-800"
+          className="text-lg font-medium leading-[140%] border-1 border-gray-300 rounded-lg dark:bg-neutral-800"
         >
-          Filter
+          <HiOutlineAdjustmentsHorizontal size={40} />
         </button>
 
         {isFilterOpen && (
           <div className="absolute top-10 right-0 z-10">
-            <div className="bg-red-200 p-6 w-72 dark:bg-neutral-800">
+            <div className="bg-[#eee] p-6 w-72 dark:bg-neutral-800">
               <div className="flex justify-between items-center mb-4">
-                <h2 className="text-l font-bold">카테고리</h2>
+                <h2 className="text-l font-bold leading-[140%]">카테고리</h2>
                 <div className="flex justify-end space-x-2">
                   <button
                     onClick={() => setSelectedCategories(['ALL'])}
@@ -80,15 +81,15 @@ const LectureListPage = () => {
                   </button>
                 </div>
               </div>
-              <div className="space-y-2">
+              <div className="space-y-3">
                 <label className="flex items-center">
                   <input
                     type="checkbox"
                     checked={selectedCategories.includes('ALL')}
                     onChange={() => setSelectedCategories(['ALL'])}
-                    className="mr-2"
+                    className="mr-3 text-base font-semibold leading-[140%]"
                   />
-                  ALL
+                  전체
                 </label>
                 {categories.map((category) => (
                   <label key={category} className="flex items-center">
@@ -106,7 +107,7 @@ const LectureListPage = () => {
                           );
                         }
                       }}
-                      className="mr-2"
+                      className="mr-3 text-base font-semibold leading-[140%]"
                     />
                     {category}
                   </label>
@@ -120,8 +121,8 @@ const LectureListPage = () => {
       <div className="space-y-8">
         {sortedTime.map((time) => (
           <div key={time}>
-            <h2 className="text-xl font-semibold mb-4">{time}</h2>
-            <ul className="flex flex-wrap gap-4">
+            <h2 className="text-2xl font-bold mt-8 mb-6">{time}</h2>
+            <ul className="flex flex-wrap gap-6">
               {filteredLectures[time].map((lecture) => (
                 <Card
                   key={lecture.id}

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -33,7 +33,7 @@ const Card = ({
 
   return (
     <div
-      className="overflow-hidden w-[282px] bg-white border border-[#DEE2E6] rounded-xl cursor-pointer"
+      className="overflow-hidden w-[282px] bg-white dark:bg-black border border-[#DEE2E6] rounded-xl cursor-pointer"
       onClick={handleClick}
     >
       <div className="relative">

--- a/src/app/_components/DayTab/DayTab.tsx
+++ b/src/app/_components/DayTab/DayTab.tsx
@@ -6,11 +6,11 @@ interface DayTabProps {
 
 const DayTab = ({ days, selectedDay, onSelectDay }: DayTabProps) => {
   return (
-    <div className="flex justify-between border-b-1 mb-4 ">
+    <div className="flex justify-between">
       {days.map((day) => (
         <button
           key={day}
-          className={`text-center w-full py-1 cursor-pointer ${selectedDay === day ? 'bg-gray-200 dark:bg-gray-700' : ''} hover:bg-gray-100`}
+          className={`text-center w-full px-4 py-[18px] cursor-pointer rounded-md font-bold text-xl ${selectedDay === day ? 'text-white bg-[#063C86] dark:bg-gray-700' : ''}`}
           onClick={() => onSelectDay(day)}
         >
           {day}

--- a/src/app/dummyData/lecture-list/getLectureList.json
+++ b/src/app/dummyData/lecture-list/getLectureList.json
@@ -54,6 +54,51 @@
         "end_time": "2025-03-06T13:00:00",
         "speakerName": "최길동",
         "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
+      },
+      {
+        "id": 7,
+        "title": "강의 제목7",
+        "category": "카테고리2",
+        "start_time": "2025-03-04T09:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
+      },
+      {
+        "id": 8,
+        "title": "강의 제목8",
+        "category": "카테고리1",
+        "start_time": "2025-03-04T09:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
+      },
+      {
+        "id": 9,
+        "title": "강의 제목9",
+        "category": "카테고리1",
+        "start_time": "2025-03-04T09:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
+      },
+      {
+        "id": 10,
+        "title": "강의 제목10",
+        "category": "카테고리1",
+        "start_time": "2025-03-04T09:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
+      },
+      {
+        "id": 11,
+        "title": "강의 제목11",
+        "category": "카테고리1",
+        "start_time": "2025-03-04T09:00:00",
+        "end_time": "2025-03-04T11:00:00",
+        "speakerName": "홍길동",
+        "image": "https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png"
       }
     ]
   }


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/lecture-list` → `dev`

<br/>

## ✅ 작업 내용

- 기존 low-fi wireframe을 기반으로 구현했던 강의 목록 UI를 hi-fi wireframe을 반영하여 수정
- 전체 페이지 레이아웃의 컨텐츠 최대 너비 설정 및 가운데 정렬
- DayTab 컴포넌트 디자인 수정
- 다크모드일때 카드 배경색 추가
- 강의 목록의 세션개수를 전체 세션 개수에서 **선택한 날짜의 총 세션 개수**로 변경

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| ![스크린샷 2025-03-18 오전 9 06 57](https://github.com/user-attachments/assets/b20d18c3-5486-4fb6-a8b9-ca2b8d197a9d) | ![스크린샷 2025-03-18 오전 9 06 33](https://github.com/user-attachments/assets/836c59d8-0ae0-4606-a56a-93584e59dbdd) |


<br/>

## ✏️ 앞으로의 과제

- 시간표 디자인

<br/>

## 📌 이슈 링크

- [`design/lecture-list`] #62  
