### PR TITLE
feat(header): 헤더 경로 수정 및 로그인 모달 추가

### DIFF
--- a/src/app/(route)/(main)/mainComponent/component/ScrollWrapper.tsx
+++ b/src/app/(route)/(main)/mainComponent/component/ScrollWrapper.tsx
@@ -10,7 +10,7 @@ interface ScrollWrapperProps {
 }
 
 const ScrollWrapper = ({ children, gap = 10, scrollStep = 3, className }: ScrollWrapperProps) => {
-  const viewmode = useHeaderStore((store) => store.state.mode);
+  const viewmode = useHeaderStore((store) => store.viewport.state.mode);
   const [innerWidth, setInnerWidth] = useState(0);
   const [outerWidth, setOuterWidth] = useState(0);
   const [scroll, setScroll] = useState(0);

--- a/src/app/(route)/login/admin/page.tsx
+++ b/src/app/(route)/login/admin/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div></div>;
+};
+
+export default Page;

--- a/src/app/(route)/login/admin/page.tsx
+++ b/src/app/(route)/login/admin/page.tsx
@@ -1,5 +1,13 @@
+import Link from 'next/link';
+
 const Page = () => {
-  return <div></div>;
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <Link className="w-auto px-2 py-1 bg-gray-500 text-white text-2xl" href="/admin">
+        어드민 로그인 버튼
+      </Link>
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/(route)/login/page.tsx
+++ b/src/app/(route)/login/page.tsx
@@ -1,0 +1,11 @@
+import LoginComponent from '@/_components/Login/LoginComponent';
+
+const Page = () => {
+  return (
+    <div className="w-full h-[70vh] flex justify-center items-center">
+      <LoginComponent className="scale-70" />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -1,5 +1,12 @@
+'use client';
+
 // 초기값 server -> client(상태 초기값) -> update
 const Page = () => {
+  const logout_test = () => {
+    if (typeof window === 'undefined') return;
+    // 쿠키 값 만료
+    document.cookie = 'id_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+  };
   return (
     <div className="flex w-screen">
       <div className="max-w-[1280px] px-[40px] h-auto w-full flex flex-col mt-16 mx-auto">
@@ -48,7 +55,9 @@ const Page = () => {
         <div className="w-full mt-[40px]">
           <span className="block">현재 계정에서 로그아웃합니다.</span>
           <span className="block">다시 로그인하려면 카카오 계정을 사용해 주세요</span>
-          <button className="btn block px-4 py-2 mt-6 rounded-[8px]">로그아웃</button>
+          <button onClick={logout_test} className="btn block px-4 py-2 mt-6 rounded-[8px]">
+            로그아웃
+          </button>
         </div>
 
         {/* 회원탈퇴 */}
@@ -58,7 +67,7 @@ const Page = () => {
           <span className="block">
             3. 복구가 불가능하며, 동일한 이메일로 재가입이 제한될 수 있음
           </span>
-          <button className="btn block px-4 py-2 mt-6 rounded-[8px]">로그아웃</button>
+          <button className="btn block px-4 py-2 mt-6 rounded-[8px]">회원 탈퇴</button>
         </div>
       </div>
       <div />

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -1,12 +1,17 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 // 초기값 server -> client(상태 초기값) -> update
 const Page = () => {
+  const navigation = useRouter();
   const logout_test = () => {
     if (typeof window === 'undefined') return;
     // 쿠키 값 만료
     document.cookie = 'id_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+    navigation.push('/');
   };
+
   return (
     <div className="flex w-screen">
       <div className="max-w-[1280px] px-[40px] h-auto w-full flex flex-col mt-16 mx-auto">

--- a/src/app/_components/Header/HeaderNav/HeaderNav.tsx
+++ b/src/app/_components/Header/HeaderNav/HeaderNav.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { MobileNavigation } from '@/_components/Nav/navigation/HeaderNav.mobile';
-import { WebNavList } from '@/_components/Nav/navigation/HeaderNav.web';
+import WebNavList from '@/_components/Nav/navigation/HeaderNav.web';
 import useHeaderStore from '@/_store/Header/useHeaderStore';
+import useAlarmStore from '@/_store/Header/useAlarmStore';
 import { UserRole } from '@/_types/Header/Header.type';
 import { ReactNode, useEffect, useState } from 'react';
 import { HeaderOverlay, MenuButton } from './ETC';
 import useResize from '@/_hooks/nav/useResize';
 import { Alarm } from '@/_types/Header/Alarm.type';
-import useAlarmStore from '@/_store/Header/useAlarmStore';
 
 interface Props {
   children?: ReactNode;
@@ -16,7 +16,7 @@ interface Props {
 
 // 헤더 네비게이션
 const HeaderNav = ({ children }: Props) => {
-  const [role, setRole] = useState<UserRole>('viewer'); // 임시 상태 버튼
+  const [role, setRole] = useState<UserRole>('viewer');
   const [isToggle, setIsToggle] = useState(false);
   const viewmode = useHeaderStore((store) => store.state.mode);
   const toggleNavMobile = (state: boolean) => setIsToggle(state);
@@ -85,9 +85,7 @@ const HeaderNav = ({ children }: Props) => {
     return (
       <>
         <button onClick={changeRole}>{`권한 변경 버튼(${role})`}</button>
-        <WebNavList role={role} nickName={GetNickName(role)}>
-          {children}
-        </WebNavList>
+        <WebNavList nickName={GetNickName(role)}>{children}</WebNavList>
       </>
     );
   }

--- a/src/app/_components/Header/HeaderNav/HeaderNav.tsx
+++ b/src/app/_components/Header/HeaderNav/HeaderNav.tsx
@@ -5,10 +5,12 @@ import WebNavList from '@/_components/Nav/navigation/HeaderNav.web';
 import useHeaderStore from '@/_store/Header/useHeaderStore';
 import useAlarmStore from '@/_store/Header/useAlarmStore';
 import { UserRole } from '@/_types/Header/Header.type';
-import { ReactNode, useEffect, useState } from 'react';
-import { HeaderOverlay, MenuButton } from './ETC';
-import useResize from '@/_hooks/nav/useResize';
+import { useHeaderRole } from '@/_hooks/nav/useNav';
 import { Alarm } from '@/_types/Header/Alarm.type';
+import ToggleModal from '@/_components/ToggleModal';
+import useResize from '@/_hooks/nav/useResize';
+import { ReactNode, useEffect } from 'react';
+import { MenuButton } from './ETC';
 
 interface Props {
   children?: ReactNode;
@@ -16,12 +18,28 @@ interface Props {
 
 // 헤더 네비게이션
 const HeaderNav = ({ children }: Props) => {
-  const [role, setRole] = useState<UserRole>('viewer');
-  const [isToggle, setIsToggle] = useState(false);
-  const viewmode = useHeaderStore((store) => store.state.mode);
-  const toggleNavMobile = (state: boolean) => setIsToggle(state);
+  const headerRole = useHeaderRole();
   const addAlarm = useAlarmStore((store) => store.actions.addAlarm);
+  const viewmode = useHeaderStore((store) => store.viewport.state.mode);
+  const isMobileNavOpen = useHeaderStore((store) => store.mobileNavOpen.state.isOpen);
+  const openMobileNav = useHeaderStore((store) => store.mobileNavOpen.actions.setOpen);
+  const closeMobileNav = useHeaderStore((store) => store.mobileNavOpen.actions.setClose);
 
+  const nickname: Record<UserRole, string> = {
+    admin: 'admin',
+    viewer: '김철수',
+    'no-login': '로그인',
+  };
+
+  // 리사이즈 훅
+  useResize();
+
+  // web이면 메뉴 닫음
+  useEffect(() => {
+    if (viewmode === 'web') closeMobileNav();
+  }, [viewmode, closeMobileNav]);
+
+  // 더미 삭제 예정
   const dumyData: Alarm[] = [
     {
       id: 1,
@@ -46,31 +64,7 @@ const HeaderNav = ({ children }: Props) => {
     },
   ];
 
-  // 리사이즈 훅
-  useResize();
-
-  // web이면 메뉴 닫음
-  useEffect(() => {
-    if (viewmode === 'web') setIsToggle(false);
-  }, [viewmode, setIsToggle]);
-
-  // 가상 넥넴
-  const GetNickName = (role: UserRole) => {
-    if (role === 'no-login') return 'null';
-    if (role === 'viewer') return '김철수';
-    return 'admin';
-  };
-
-  // 가상 권한
-  const changeRole = () => {
-    setRole((prev) => {
-      if (prev === 'viewer') return 'admin';
-      if (prev === 'admin') return 'no-login';
-      return 'viewer';
-    });
-  };
-
-  // SSE 여기에 이벤트 구독 필요
+  // 더미 삭제 예정
   useEffect(() => {
     localStorage.removeItem('alarm-storage');
     dumyData.forEach((item, idx) => {
@@ -84,8 +78,9 @@ const HeaderNav = ({ children }: Props) => {
   if (viewmode === 'web') {
     return (
       <>
-        <button onClick={changeRole}>{`권한 변경 버튼(${role})`}</button>
-        <WebNavList nickName={GetNickName(role)}>{children}</WebNavList>
+        <WebNavList {...headerRole} nickName={nickname[headerRole.role]}>
+          {children}
+        </WebNavList>
       </>
     );
   }
@@ -93,13 +88,17 @@ const HeaderNav = ({ children }: Props) => {
   /** 모바일 모드 **/
   return (
     <>
-      {isToggle && (
-        <>
-          <MobileNavigation role={role} nickName={GetNickName(role)} />
-          <HeaderOverlay onClickHandler={() => toggleNavMobile(false)} />
-        </>
-      )}
-      {!isToggle && <MenuButton onClickHandler={() => toggleNavMobile(true)} />}
+      <ToggleModal
+        isMobile={true}
+        desc="mobile-nav"
+        hasOverlay={true}
+        onClose={closeMobileNav}
+        isOpen={isMobileNavOpen}
+      >
+        <MobileNavigation {...headerRole} nickName={nickname[headerRole.role]} />
+      </ToggleModal>
+
+      {!isMobileNavOpen && <MenuButton onClickHandler={openMobileNav} />}
     </>
   );
 };

--- a/src/app/_components/Login/LoginComponent.tsx
+++ b/src/app/_components/Login/LoginComponent.tsx
@@ -1,0 +1,37 @@
+'use client';
+import KaKaoLogoSvg from '@/assets/Header/kakaologo.svg';
+import useLogin from '@/_hooks/login/useLogin';
+import ClickButton from '../ClickButton';
+import { HTMLAttributes } from 'react';
+import Link from 'next/link';
+
+const LoginComponent = (props: HTMLAttributes<HTMLElement>) => {
+  const { loginWithKakao } = useLogin();
+  return (
+    <div {...props}>
+      <div className="flex flex-col justify-center items-center gap-6">
+        <span className="font-bold text-5xl">IT TIME</span>
+        <span className="text-2xl text-wrap">로그인하고 더 편하게 IT 컨퍼런스를 즐겨보세요</span>
+      </div>
+      <div className="flex flex-col mt-11 gap-[14px]">
+        <ClickButton
+          actionDesc="user-kakao-login"
+          onClickAction={loginWithKakao}
+          className="px-7 h-[90px] flex justify-center items-center gap-4 rounded-[12px] bg-[#FEE500] cursor-pointer"
+        >
+          <KaKaoLogoSvg width="36px" height="36px" />
+          <span className="text-3xl">카카오 로그인</span>
+        </ClickButton>
+
+        <Link
+          href="/login/admin"
+          className="px-7 h-[90px] flex justify-center items-center gap-4 rounded-[12px] bg-[#9e9e9e]  cursor-pointer"
+        >
+          <span className="text-3xl text-[#ffffff]">관리자 로그인</span>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default LoginComponent;

--- a/src/app/_components/Login/LoginComponent.tsx
+++ b/src/app/_components/Login/LoginComponent.tsx
@@ -5,7 +5,11 @@ import ClickButton from '../ClickButton';
 import { HTMLAttributes } from 'react';
 import Link from 'next/link';
 
-const LoginComponent = (props: HTMLAttributes<HTMLElement>) => {
+interface Props extends HTMLAttributes<HTMLElement> {
+  onClose?: () => void;
+}
+
+const LoginComponent = ({ onClose, ...props }: Props) => {
   const { loginWithKakao } = useLogin();
   return (
     <div {...props}>
@@ -16,7 +20,10 @@ const LoginComponent = (props: HTMLAttributes<HTMLElement>) => {
       <div className="flex flex-col mt-11 gap-[14px]">
         <ClickButton
           actionDesc="user-kakao-login"
-          onClickAction={loginWithKakao}
+          onClickAction={() => {
+            if (onClose) onClose();
+            loginWithKakao();
+          }}
           className="px-7 h-[90px] flex justify-center items-center gap-4 rounded-[12px] bg-[#FEE500] cursor-pointer"
         >
           <KaKaoLogoSvg width="36px" height="36px" />
@@ -24,6 +31,7 @@ const LoginComponent = (props: HTMLAttributes<HTMLElement>) => {
         </ClickButton>
 
         <Link
+          onClick={onClose}
           href="/login/admin"
           className="px-7 h-[90px] flex justify-center items-center gap-4 rounded-[12px] bg-[#9e9e9e]  cursor-pointer"
         >

--- a/src/app/_components/Nav/navigation/HeaderNav.mobile.tsx
+++ b/src/app/_components/Nav/navigation/HeaderNav.mobile.tsx
@@ -1,14 +1,16 @@
 import { NavItem, NavSectionProps, UserRole } from '@/_types/Header/Header.type';
-import { useNav } from '@/_hooks/nav/useNav';
+import { HeaderRoleState, useNav } from '@/_hooks/nav/useNav';
+import useHeaderStore from '@/_store/Header/useHeaderStore';
 import Right from '@/assets/Header/right.svg';
 import Link from 'next/link';
 import { Nav } from '../nav';
 
-const MobileNavTop = ({ nickName }: { nickName: string }) => {
+const MobileNavTop = ({ nickName, path }: { nickName: string; path: string }) => {
+  const onClose = useHeaderStore((store) => store.mobileNavOpen.actions.setClose);
   return (
-    <div className="flex items-end h-[28px] mb-2 gap-[0.5px]">
+    <Link href={path} onClick={onClose} className="flex items-end h-[28px] mb-2 gap-[0.5px]">
       <span className="text-[14px]">{nickName}</span>
-    </div>
+    </Link>
   );
 };
 
@@ -24,12 +26,15 @@ const MobileNavSection = ({ section, renderItem }: NavSectionProps) => {
 };
 
 const MobileNavItem = ({ path, title }: NavItem) => {
+  const onCloseModal = useHeaderStore((state) => state.mobileNavOpen.actions.setClose);
   return (
     <li key={title} className="py-[0.4rem] flex justify-between items-center cursor-pointer">
       <div className="flex items-center gap-2">
         <div className="w-[16px] h-[16px] bg-[#7373739a] rounded-[4px] flex justify-center items-center"></div>
         <span>
-          <Link href={path}>{title}</Link>
+          <Link onClick={onCloseModal} href={path}>
+            {title}
+          </Link>
         </span>
       </div>
       <Right width="20" height="20" />
@@ -39,18 +44,23 @@ const MobileNavItem = ({ path, title }: NavItem) => {
 
 // -------------네비게이션--------------
 
-interface Props {
-  role: UserRole;
+interface Props extends HeaderRoleState {
   nickName: string;
 }
 
-export const MobileNavigation = ({ role, nickName }: Props) => {
+export const MobileNavigation = ({ nickName, role }: Props) => {
   const { mobile } = useNav(role);
+
+  const path: Record<UserRole, string> = {
+    admin: '/admin',
+    viewer: '/mypage',
+    'no-login': '/login',
+  };
 
   return (
     <Nav
       navDto={mobile}
-      renderTop={() => (role !== 'no-login' ? <MobileNavTop nickName={nickName} /> : <></>)}
+      renderTop={() => <MobileNavTop nickName={nickName} path={path[role]} />}
       renderItem={(item) => <MobileNavItem key={item.title} {...item} />}
       renderSection={(section, renderItem) => (
         <MobileNavSection key={section.title} section={section} renderItem={renderItem} />

--- a/src/app/_components/Nav/navigation/HeaderNav.web.tsx
+++ b/src/app/_components/Nav/navigation/HeaderNav.web.tsx
@@ -1,19 +1,41 @@
+'use client';
 import { NavItem, UserRole } from '@/_types/Header/Header.type';
+import LoginComponent from '@/_components/Login/LoginComponent';
 import Alarm from '@/_components/Header/Alarm/Alarm';
 import { usePathname } from 'next/navigation';
 import { useNav } from '@/_hooks/nav/useNav';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import Link from 'next/link';
+import ToggleModal from '@/_components/ToggleModal';
+import ClickButton from '@/_components/ClickButton';
 
 interface WebNavListProps {
-  role: UserRole;
   nickName: string;
   children?: ReactNode;
 }
 
 // 웹
-export const WebNavList = ({ role, nickName, children }: WebNavListProps) => {
+const WebNavList = ({ nickName, children }: WebNavListProps) => {
+  const [clientPathname, setClientPathname] = useState<string | null>(null);
+  const [role, setRole] = useState<UserRole>('no-login');
   const pathname = usePathname();
+
+  // 액세스 토큰 유무 확인 (클라이언트에서만 실행)
+  useEffect(() => {
+    setClientPathname(pathname);
+    if (typeof window !== 'undefined') {
+      const cookies = document.cookie.split('; ');
+      for (const cookie of cookies) {
+        const [key] = cookie.split('=');
+        if (key === 'id_token') {
+          setRole(pathname === '/admin' ? 'admin' : 'viewer');
+          return;
+        }
+      }
+      setRole('no-login');
+    }
+  }, [pathname]);
+
   const { web } = useNav(role);
 
   return (
@@ -28,16 +50,52 @@ export const WebNavList = ({ role, nickName, children }: WebNavListProps) => {
         </ol>
       </nav>
 
-      {!pathname.startsWith('/admin') && role !== 'no-login' && <span>{nickName}</span>}
-      {!pathname.startsWith('/admin') && role === 'viewer' && <Alarm />}
+      {!clientPathname?.startsWith('/admin') && role !== 'no-login' && (
+        <Link href="/mypage">{nickName}</Link>
+      )}
+      {!clientPathname?.startsWith('/admin') && role === 'no-login' && <LoginButton />}
+      {!clientPathname?.startsWith('/admin') && role === 'viewer' && <Alarm />}
     </div>
   );
 };
+
+export default WebNavList;
 
 const WebNavItem = ({ path, title }: NavItem) => {
   return (
     <li className="cursor-pointer px-2 py-3 text-nowrap" key={title}>
       <Link href={path}>{title}</Link>
     </li>
+  );
+};
+
+const LoginButton = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onClose = () => setIsOpen(false);
+  const onOpen = () => setIsOpen(true);
+
+  return (
+    <>
+      <div>
+        <ClickButton actionDesc="open-login-modal" onClickAction={onOpen}>
+          로그인
+        </ClickButton>
+        <ToggleModal desc="login-modal" isOpen={isOpen} onClose={onClose} hasOverlay={true}>
+          <div className="relative">
+            <div className="fixed z-[1000] top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2">
+              <div className="text-black dark:text-white bg-white dark:bg-black w-[768px] h-[720px] px-[83px] flex flex-col justify-center scale-80">
+                <button
+                  onClick={onClose}
+                  className="text-2xl absolute top-[0.5rem] right-[1rem] cursor-pointer"
+                >
+                  x
+                </button>
+                <LoginComponent />
+              </div>
+            </div>
+          </div>
+        </ToggleModal>
+      </div>
+    </>
   );
 };

--- a/src/app/_components/Nav/navigation/HeaderNav.web.tsx
+++ b/src/app/_components/Nav/navigation/HeaderNav.web.tsx
@@ -1,43 +1,27 @@
 'use client';
-import { NavItem, UserRole } from '@/_types/Header/Header.type';
+
 import LoginComponent from '@/_components/Login/LoginComponent';
+import { HeaderRoleState, useNav } from '@/_hooks/nav/useNav';
+import { NavItem } from '@/_types/Header/Header.type';
 import Alarm from '@/_components/Header/Alarm/Alarm';
-import { usePathname } from 'next/navigation';
-import { useNav } from '@/_hooks/nav/useNav';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import Link from 'next/link';
 import ToggleModal from '@/_components/ToggleModal';
 import ClickButton from '@/_components/ClickButton';
 
-interface WebNavListProps {
-  nickName: string;
+interface WebNavListProps extends HeaderRoleState {
   children?: ReactNode;
+  nickName?: string;
 }
 
 // 웹
-const WebNavList = ({ nickName, children }: WebNavListProps) => {
-  const [clientPathname, setClientPathname] = useState<string | null>(null);
-  const [role, setRole] = useState<UserRole>('no-login');
-  const pathname = usePathname();
-
-  // 액세스 토큰 유무 확인 (클라이언트에서만 실행)
-  useEffect(() => {
-    setClientPathname(pathname);
-    if (typeof window !== 'undefined') {
-      const cookies = document.cookie.split('; ');
-      for (const cookie of cookies) {
-        const [key] = cookie.split('=');
-        if (key === 'id_token') {
-          setRole(pathname === '/admin' ? 'admin' : 'viewer');
-          return;
-        }
-      }
-      setRole('no-login');
-    }
-  }, [pathname]);
-
+const WebNavList = ({ children, role, pathname, nickName }: WebNavListProps) => {
   const { web } = useNav(role);
 
+  const path = {
+    admin: '/admin',
+    viewer: '/mypage',
+  };
   return (
     <div className="flex justify-center items-center gap-2 select-none text-[18px]">
       <nav>
@@ -50,11 +34,11 @@ const WebNavList = ({ nickName, children }: WebNavListProps) => {
         </ol>
       </nav>
 
-      {!clientPathname?.startsWith('/admin') && role !== 'no-login' && (
-        <Link href="/mypage">{nickName}</Link>
+      {!pathname?.startsWith('/admin') && role !== 'no-login' && (
+        <Link href={path[role]}>{nickName}</Link>
       )}
-      {!clientPathname?.startsWith('/admin') && role === 'no-login' && <LoginButton />}
-      {!clientPathname?.startsWith('/admin') && role === 'viewer' && <Alarm />}
+      {role === 'no-login' && <LoginButton />}
+      {role === 'viewer' && <Alarm />}
     </div>
   );
 };
@@ -90,7 +74,7 @@ const LoginButton = () => {
                 >
                   x
                 </button>
-                <LoginComponent />
+                <LoginComponent onClose={onClose} />
               </div>
             </div>
           </div>

--- a/src/app/_components/ToggleModal.tsx
+++ b/src/app/_components/ToggleModal.tsx
@@ -6,6 +6,7 @@ export interface ToggleModalProps extends HTMLAttributes<HTMLDivElement> {
   hasOverlay?: boolean; // 오버레이 유무
   children: React.ReactNode; // 자식 노드
   onClose: () => void; // 모달 off 함수
+  isMobile?: boolean;
 }
 
 // 모달 내부를 제외한 어디를 클릭을 하던 모달은 닫힘
@@ -13,6 +14,7 @@ const ToggleModal = ({
   desc,
   isOpen,
   children,
+  isMobile = false,
   hasOverlay = false,
   onClose,
   ...props
@@ -41,7 +43,7 @@ const ToggleModal = ({
 
   return (
     <>
-      {hasOverlay && <Overlay />}
+      {hasOverlay && <Overlay isMobile={isMobile} />}
       <div
         id={`modal-${desc}`}
         role="dialog"
@@ -59,11 +61,11 @@ const ToggleModal = ({
   );
 };
 
-const Overlay = () => {
+const Overlay = ({ isMobile }: { isMobile: boolean }) => {
   const TOP_GAP = 78.32;
   return (
     <div
-      style={{ height: `calc(100vh - ${TOP_GAP}px )` }}
+      style={{ height: isMobile === false ? `calc(100vh - ${TOP_GAP}px )` : '100vh' }}
       className="fixed z-100 w-screen bottom-0 bg-[#8181815e] left-0"
     />
   );

--- a/src/app/_hooks/login/useLogin.ts
+++ b/src/app/_hooks/login/useLogin.ts
@@ -15,9 +15,9 @@ const useLogin = () => {
 
     const curURL = window.location.href;
     const redirectUri = `${BASE_URL}/auth`;
-
-    // 이전 경로 기억
-    sessionStorage.setItem('prevUrl', curURL);
+    const curPath = window.location.pathname;
+    // 모달에서 로그인 할시 현재 경로 기억
+    if (curPath === '/login') sessionStorage.setItem('prevUrl', curURL);
 
     window.Kakao.Auth.authorize({
       redirectUri,

--- a/src/app/_hooks/nav/navDto.ts
+++ b/src/app/_hooks/nav/navDto.ts
@@ -4,7 +4,8 @@ import { NavGroup, NavigationConfig, NavItem } from '@/_types/Header/Header.type
 const web: NavItem[] = [
   { title: '강의 목록', path: '/lecture-list', roles: ['no-login', 'viewer'] },
   { title: '시간표 관리', path: '/timetable', roles: ['no-login', 'viewer'] },
-  { title: '관리자 페이지', path: '/admin', roles: ['admin'] },
+  { title: '대시보드', path: '/admin', roles: ['admin'] },
+  { title: '알림관리', path: '/admin', roles: ['admin'] },
 ]; // 마이페이지랑 운영자 같은 경우 이름을 클릭하면 이동한다. 마이페이지 배제
 
 // 모바일 네비게이션 목록
@@ -24,12 +25,12 @@ const mobile: NavGroup[] = [
     title: '운영 서비스',
     items: [
       { title: '대시 보드', path: '/admin', roles: ['admin'] },
-      { title: '강의 리스트', path: '#', roles: ['admin'] },
+      // { title: '강의 리스트', path: '#', roles: ['admin'] },
     ],
   },
   {
     title: '알림 관리',
-    items: [{ title: '알림 보내기', path: '#', roles: ['admin'] }],
+    items: [{ title: '알림 보내기', path: 'admin/alarm', roles: ['admin'] }],
   },
 ];
 

--- a/src/app/_hooks/nav/useNav.ts
+++ b/src/app/_hooks/nav/useNav.ts
@@ -1,6 +1,8 @@
+'use client';
 import { NavItem, UserRole } from '@/_types/Header/Header.type';
 import { navInfo } from './navDto';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 const filterAccessibleNavItems = (items: NavItem[], userRole: UserRole) =>
   items.filter((item) => item.roles?.includes(userRole));
@@ -22,4 +24,41 @@ export const useNav = (userRole: UserRole) => {
   return useMemo(() => {
     return getUserNavigation(userRole);
   }, [userRole]);
+};
+
+/* 
+1. path가 admin 경로면 admin 권한
+2. 액세스 토큰이 있다면 viewer
+3. 해당하지 않으면 no-login
+*/
+export interface HeaderRoleState {
+  role: UserRole;
+  pathname: string;
+}
+
+export const useHeaderRole = (): HeaderRoleState => {
+  const [role, setRole] = useState<UserRole>('no-login');
+  const pathname = usePathname();
+
+  const findToken = (tokenName: string): boolean => {
+    if (typeof window === 'undefined') return false;
+
+    return document.cookie.split('; ').some((cookie) => cookie.startsWith(`${tokenName}=`));
+  };
+
+  useEffect(() => {
+    let newRole: UserRole = 'no-login';
+
+    if (pathname.startsWith('/admin')) {
+      newRole = 'admin';
+    } else if (findToken('admin_token')) {
+      newRole = 'admin';
+    } else if (findToken('id_token')) {
+      newRole = 'viewer';
+    }
+
+    setRole((prevRole) => (prevRole !== newRole ? newRole : prevRole));
+  }, [pathname]);
+
+  return { role, pathname };
 };

--- a/src/app/_hooks/nav/useResize.ts
+++ b/src/app/_hooks/nav/useResize.ts
@@ -5,8 +5,8 @@ import { useEffect } from 'react';
 
 const useResize = () => {
   const MAX_MOBILE_WIDTH = 769;
-  const setWidth = useHeaderStore((store) => store.actions.setWidth);
-  const setMode = useHeaderStore((store) => store.actions.setMode);
+  const setWidth = useHeaderStore((store) => store.viewport.actions.setWidth);
+  const setMode = useHeaderStore((store) => store.viewport.actions.setMode);
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout;

--- a/src/app/_store/Header/useHeaderStore.ts
+++ b/src/app/_store/Header/useHeaderStore.ts
@@ -14,28 +14,63 @@ interface ViewportActions {
   setMode: (mode: ViewMode) => void;
 }
 
-type HeaderSlice = BaseSlice<ViewportState, ViewportActions>;
+interface MobileNavOpenState {
+  isOpen: boolean;
+}
+
+interface MobileNavOpenAction {
+  setOpen: () => void;
+  setClose: () => void;
+}
+
+type HeaderSlice = {
+  viewport: BaseSlice<ViewportState, ViewportActions>;
+  mobileNavOpen: BaseSlice<MobileNavOpenState, MobileNavOpenAction>;
+};
 
 // 해더 스토어
 const useHeaderStore = create<HeaderSlice>((set) => ({
-  state: {
-    mode: 'web',
-    width: 1920,
-  },
-  actions: {
-    setWidth(width: number) {
-      set(
-        produce<HeaderSlice>((store) => {
-          store.state.width = width;
-        }),
-      );
+  viewport: {
+    state: {
+      mode: 'web',
+      width: 1920,
     },
-    setMode(mode: ViewMode) {
-      set(
-        produce<HeaderSlice>((store) => {
-          store.state.mode = mode;
-        }),
-      );
+    actions: {
+      setWidth(width: number) {
+        set(
+          produce<HeaderSlice>((store) => {
+            store.viewport.state.width = width;
+          }),
+        );
+      },
+      setMode(mode: ViewMode) {
+        set(
+          produce<HeaderSlice>((store) => {
+            store.viewport.state.mode = mode;
+          }),
+        );
+      },
+    },
+  },
+  mobileNavOpen: {
+    state: {
+      isOpen: false,
+    },
+    actions: {
+      setOpen() {
+        set(
+          produce<HeaderSlice>((store) => {
+            store.mobileNavOpen.state.isOpen = true;
+          }),
+        );
+      },
+      setClose() {
+        set(
+          produce<HeaderSlice>((store) => {
+            store.mobileNavOpen.state.isOpen = false;
+          }),
+        );
+      },
     },
   },
 }));

--- a/src/app/_utils/Header/admin.ts
+++ b/src/app/_utils/Header/admin.ts
@@ -1,0 +1,50 @@
+export const issuanceAdminToken = async () => {
+  try {
+    const res = await fetch('/api/auth/admin', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+
+    if (res.ok) {
+      return true;
+    }
+    throw new Error();
+  } catch {
+    return false;
+  }
+};
+
+export const delAdminToken = async () => {
+  try {
+    const res = await fetch('/api/auth/admin', {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+
+    if (res.ok) {
+      return true;
+    }
+    throw new Error();
+  } catch {
+    return false;
+  }
+};
+
+export const checkAdminToken = async () => {
+  try {
+    const res = await fetch('/api/auth/admin', {
+      method: 'GET',
+      credentials: 'include',
+    });
+
+    if (res.ok) {
+      return true;
+    }
+    throw new Error();
+  } catch {
+    return false;
+  }
+};

--- a/src/app/api/auth/admin/route.ts
+++ b/src/app/api/auth/admin/route.ts
@@ -1,0 +1,47 @@
+import { cookies } from 'next/headers';
+
+// 발급
+export const POST = async () => {
+  const cookieStore = await cookies();
+
+  cookieStore.set('admin_token', 'true', {
+    httpOnly: false,
+    secure: true,
+    path: '/',
+    maxAge: 60 * 5,
+  });
+
+  return new Response(JSON.stringify({ message: '로그인 성공' }), {
+    status: 200,
+  });
+};
+
+// 권한 확인
+export const GET = async () => {
+  const cookieStore = await cookies();
+  const adminToken = cookieStore.get('admin_token');
+
+  if (!adminToken) {
+    return new Response(JSON.stringify({ admin: false }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ admin: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+// 권한 삭제
+export const DELETE = async () => {
+  const cookieStore = await cookies();
+
+  cookieStore.delete('admin_token');
+
+  return new Response(JSON.stringify({ message: '로그아웃 성공' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/app/assets/Header/kakaologo.svg
+++ b/src/app/assets/Header/kakaologo.svg
@@ -1,0 +1,10 @@
+<svg width="37" height="36" viewBox="0 0 37 36" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1129_12904)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.5 1.19922C8.55835 1.19922 0.5 7.42514 0.5 15.1038C0.5 19.8793 3.61681 24.0892 8.36305 26.5931L6.36606 33.8882C6.18962 34.5328 6.92683 35.0466 7.49293 34.6731L16.2467 28.8956C16.9854 28.9669 17.7362 29.0085 18.5 29.0085C28.4409 29.0085 36.4999 22.7828 36.4999 15.1038C36.4999 7.42514 28.4409 1.19922 18.5 1.19922Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_1129_12904">
+<rect width="35.9999" height="36" fill="white" transform="translate(0.5)"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/header` → `dev`

<br/>

## ✅ 작업 내용

- **로그인 모달 추가**
- **모바일 헤더 개선**
  - 로그인 버튼 클릭 시 /login 페이지로 리다이렉트
- **카카오 로그인 기능 추가**
  - 로그인 시 id_token을 발급받아 쿠키에 저장 후 로그아웃 처리(id_token만 필요함 카카오 액세스 토큰 제거)
  - 현재 id_token을 기반으로 로그인 여부를 판단 (추후 액세스 토큰 여부로 변경 할 예정)
 - **관리자 로그인 기능 추가**
   - 관리자 로그인 버튼 클릭 시 /admin/login 페이지로 리다이렉트
   - 유저 정보에 별도의 권한 속성이 없어, 서버에서 자체적으로 admin_token 발급
   - admin_token이 쿠키에 존재하면 관리자 헤더로 변경 
 - **관리자 헤더 알림 경로 추가**
   - /admin/alarm 경로 추가
  

어드민 토큰 발급용 Next.js API Route 생성(개발 편의성을 위해서 연결 X)



<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/bd2c8c33-e955-4df9-9701-2c741c889a48)
![image](https://github.com/user-attachments/assets/b30f7c6a-3aa5-4e40-a44d-4d5799b336e8)

비로그인 상태
![image](https://github.com/user-attachments/assets/81898b28-f495-4dc2-9aa9-457818d459eb)
로그인 상태
![image](https://github.com/user-attachments/assets/7cf80f45-d74d-4351-ac9d-45bb59923865)

관리자 로그인 상태
![image](https://github.com/user-attachments/assets/79f45b8e-b31c-4d3d-8cff-82a4eaaef158)

관리자 페이지 admin이 지워짐
![image](https://github.com/user-attachments/assets/06363b84-92f0-4dca-960c-b45b3a2308b8)


<br/>

## ✏️ 앞으로의 과제

- 강의 상세 페이지 퍼블리싱


<br/>

## 📌 이슈 링크

- [`feat/header` #69 ]
