### PR TITLE
feat(timetable): 시간표 페이지 구조 변경

### DIFF
--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -111,6 +111,7 @@ const TimetablePage = () => {
       }
     };
     fetchTimetable();
+    setIsLoggedIn(true);
   }, []);
 
   const fetchTimeWish = async (startTime: string) => {
@@ -119,6 +120,7 @@ const TimetablePage = () => {
       // if (!response.ok) throw new Error('즐겨찾기 강의 데이터를 불러오는 데 실패했습니다.');
 
       // const data = await response.json();
+      console.log(startTime); // never used build error 방지용
       const data = timeWishRes;
       setTimeWish(data.responses);
     } catch (error) {
@@ -132,6 +134,7 @@ const TimetablePage = () => {
       // if (!response.ok) throw new Error('추천 강의 데이터를 불러오는 데 실패했습니다.');
 
       // const data = await response.json();
+      console.log(startTime);
       const data = timeRecommandRes;
       setRecommandLectures(data.lectures);
     } catch (error) {

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -70,6 +70,7 @@ const TimetablePage = () => {
   const [baseDate, setBaseDate] = useState<Date | null>(null);
   const [timeWish, setTimeWish] = useState<TimeWishProps[]>([]);
   const [showWishlist, setShowWishlist] = useState<boolean>(false);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true); // 임시로 항상 true
 
   const router = useRouter();
 
@@ -176,9 +177,13 @@ const TimetablePage = () => {
     <div className="p-10">
       <div className="w-full flex justify-between items-center py-4">
         <h1 className="text-xl font-bold">컴퍼런스 일정 시간표</h1>
-        <button className="bg-gray-200 px-1 cursor-pointer" onClick={handleWishlistClick}>
-          즐찾
-        </button>
+        {isLoggedIn ? (
+          <button className="bg-gray-200 px-1 cursor-pointer" onClick={handleWishlistClick}>
+            즐찾
+          </button>
+        ) : (
+          <div></div>
+        )}
       </div>
       <div className="flex gap-2 w-full">
         <div className="flex-2">
@@ -187,89 +192,97 @@ const TimetablePage = () => {
             selectedDay={selectedDay}
             onSelectDay={setSelectedDay}
           />
-
-          <div className="grid border border-gray-300" style={{ gridTemplateColumns: '140px 1fr' }}>
-            {timeSlots.map(({ start, end }) => {
-              if (occupiedSlots.has(start)) {
-                return (
-                  <div
-                    key={`empty-${start}`}
-                    className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium"
-                  >
-                    {start} ~ {end}
-                  </div>
-                );
-              }
-
-              const lecture = filteredLectures.find(
-                (lecture) =>
-                  new Date(lecture.startTime).toLocaleTimeString('ko-KR', {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: false,
-                  }) === start,
-              );
-
-              const rowSpan = lecture
-                ? (new Date(lecture.endTime).getTime() - new Date(lecture.startTime).getTime()) /
-                  (60 * 60 * 1000)
-                : 1;
-
-              if (lecture) {
-                const occupiedTime = new Date(lecture.startTime);
-                for (let i = 0; i < rowSpan; i++) {
-                  const timeKey = occupiedTime.toLocaleTimeString('ko-KR', {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: false,
-                  });
-                  occupiedSlots.add(timeKey);
-                  occupiedTime.setHours(occupiedTime.getHours() + 1);
-                }
-              }
-
-              return (
-                <Fragment key={`time-${start}-${end}`}>
-                  <div className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium">
-                    {start} ~ {end}
-                  </div>
-
-                  {lecture ? (
+          {isLoggedIn ? (
+            <div
+              className="grid border border-gray-300"
+              style={{ gridTemplateColumns: '140px 1fr' }}
+            >
+              {timeSlots.map(({ start, end }) => {
+                if (occupiedSlots.has(start)) {
+                  return (
                     <div
-                      key={lecture.reservationId}
-                      className="p-4 text-left cursor-pointer"
-                      style={{
-                        gridRow: `span ${rowSpan}`,
-                        backgroundColor: '#fff',
-                        border: '1px solid #ccc',
-                        borderBottom: rowSpan > 1 ? 'none' : '1px solid #ccc',
-                      }}
-                      onClick={() => router.push(`/lecture/${lecture.lectureId}`)}
+                      key={`empty-${start}`}
+                      className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium"
                     >
-                      <p className="w-fit bg-gray-200 px-1">{lecture.location}</p>
-                      <p>{lecture.title}</p>
-                      <div className="flex justify-between">
-                        <p>{lecture.speakerName}</p>
-                        <p>
-                          인원수 {lecture.currentReservation} / {lecture.capacity}
-                        </p>
-                      </div>
+                      {start} ~ {end}
                     </div>
-                  ) : (
-                    <div
-                      className="border border-gray-300 bg-gray-50 hover:bg-gray-200 cursor-pointer"
-                      style={{
-                        gridRow: 'span 1',
-                      }}
-                      onClick={() =>
-                        handleEmptySlotClick(Number(selectedDay.replace('Day', '')), start)
-                      }
-                    />
-                  )}
-                </Fragment>
-              );
-            })}
-          </div>
+                  );
+                }
+
+                const lecture = filteredLectures.find(
+                  (lecture) =>
+                    new Date(lecture.startTime).toLocaleTimeString('ko-KR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hour12: false,
+                    }) === start,
+                );
+
+                const rowSpan = lecture
+                  ? (new Date(lecture.endTime).getTime() - new Date(lecture.startTime).getTime()) /
+                    (60 * 60 * 1000)
+                  : 1;
+
+                if (lecture) {
+                  const occupiedTime = new Date(lecture.startTime);
+                  for (let i = 0; i < rowSpan; i++) {
+                    const timeKey = occupiedTime.toLocaleTimeString('ko-KR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hour12: false,
+                    });
+                    occupiedSlots.add(timeKey);
+                    occupiedTime.setHours(occupiedTime.getHours() + 1);
+                  }
+                }
+
+                return (
+                  <Fragment key={`time-${start}-${end}`}>
+                    <div className="flex justify-center items-center border border-gray-300 bg-gray-100 p-3 h-full text-center font-medium">
+                      {start} ~ {end}
+                    </div>
+
+                    {lecture ? (
+                      <div
+                        key={lecture.reservationId}
+                        className="p-4 text-left cursor-pointer"
+                        style={{
+                          gridRow: `span ${rowSpan}`,
+                          backgroundColor: '#fff',
+                          border: '1px solid #ccc',
+                          borderBottom: rowSpan > 1 ? 'none' : '1px solid #ccc',
+                        }}
+                        onClick={() => router.push(`/lecture/${lecture.lectureId}`)}
+                      >
+                        <p className="w-fit bg-gray-200 px-1">{lecture.location}</p>
+                        <p>{lecture.title}</p>
+                        <div className="flex justify-between">
+                          <p>{lecture.speakerName}</p>
+                          <p>
+                            인원수 {lecture.currentReservation} / {lecture.capacity}
+                          </p>
+                        </div>
+                      </div>
+                    ) : (
+                      <div
+                        className="border border-gray-300 bg-gray-50 hover:bg-gray-200 cursor-pointer"
+                        style={{
+                          gridRow: 'span 1',
+                        }}
+                        onClick={() =>
+                          handleEmptySlotClick(Number(selectedDay.replace('Day', '')), start)
+                        }
+                      />
+                    )}
+                  </Fragment>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex justify-center items-center h-[690px] bg-gray-100">
+              로그인 이후 이용 가능합니다.
+            </div>
+          )}
         </div>
 
         {selectedTime && (

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -2,127 +2,140 @@
 
 import { useEffect, useState, Fragment } from 'react';
 import { useRouter } from 'next/navigation';
-import response from '@/dummyData/timetable/getTimetable.json';
-import wishlistResponse from '@/dummyData/wishlist/getWishlist.json';
-import recommandLecturesDummy from '@/dummyData/timetable/getTimetableRecommand.json';
+import timetableRes from '@/dummyData/timetable/getTimetable.json';
+import timeWishRes from '@/dummyData/timetable/getTimeWish.json';
+import timeRecommandRes from '@/dummyData/timetable/getTimetableRecommand.json';
 import DayTab from '@/_components/DayTab/DayTab';
 
 interface LectureProps {
-  id: number;
+  reservationId: number;
+  userId: number;
+  lectureId: number;
   title: string;
-  start_time: string;
-  end_time: string;
+  startTime: string;
+  endTime: string;
+  currentReservation: number;
+  capacity: number;
+  location: string;
+  speakerName: string;
   day?: number;
-  location: string;
-  speaker: string;
-  count: number;
-  total: number;
-  lecture_id: number;
-}
-
-interface UserLectures {
-  reservation: LectureProps[];
-  wishlist: LectureProps[];
-}
-
-interface RecommandLectureProps {
-  lecture_id: number;
-  title: string;
-  start_time: string;
-  end_time: string;
-  location: string;
-  speaker: string;
 }
 
 interface WishLectureProps {
-  id: number;
-  lectureTitle: string;
+  wishlistId: number;
+  userId: number;
+  lectureId: number;
+  title: string;
   startTime: string;
   endTime: string;
-  speaker: string;
+  currentReservation: number;
+  capacity: number;
+  location: string;
+  speakerName: string;
+}
+
+interface RecommandLectureProps {
+  id: number;
+  title: string;
+  category: string;
+  startTime: string;
+  endTime: string;
+  speakerName: string;
+  speakerImageUri: string;
+  location?: string;
+}
+
+interface TimeWishProps {
+  category: string;
+  thumbnailUri: string;
+  title: string;
+  contents: string;
+  speakerName: string;
+  startTime: string;
+  endTime: string;
   location: string;
 }
 
 const TimetablePage = () => {
-  const [userLectures, setUserLectures] = useState<UserLectures>({ reservation: [], wishlist: [] });
+  const [userLectures, setUserLectures] = useState<{
+    reservation: LectureProps[];
+    wishlist: WishLectureProps[];
+  }>({
+    reservation: [],
+    wishlist: [],
+  });
   const [selectedDay, setSelectedDay] = useState<string>('Day1');
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
   const [recommandLectures, setRecommandLectures] = useState<RecommandLectureProps[]>([]);
   const [baseDate, setBaseDate] = useState<Date | null>(null);
-  const [wishlist, setWishlist] = useState<WishLectureProps[]>([]);
+  const [timeWish, setTimeWish] = useState<TimeWishProps[]>([]);
   const [showWishlist, setShowWishlist] = useState<boolean>(false);
 
   const router = useRouter();
-  const currentUserId = 222; // 현재 로그인한 유저 ID 가져오는 로직 추가
 
   useEffect(() => {
-    // const fetchUserLectures = async () => {
-    //   try {
-    //     const response = await fetch(`/api/attendees/${currentUserId}/timetable`);
-    //     if (!response.ok) {
-    //       throw new Error('네트워크 응답 오류');
-    //     }
-    //     const data: UserLectures = await response.json();
-    //     const userReservations = data.reservation.filter((lecture) => lecture.user_id === userId);
-    //     const userWishlist = data.wishlist.filter((lecture) => lecture.user_id === userId);
+    const fetchTimetable = async () => {
+      try {
+        // const response = await fetch('/api/timetables/me');
+        // if (!response.ok) {
+        //   throw new Error('네트워크 응답 오류');
+        // }
+        // const data = await response.json();
+        const data = timetableRes;
+        setUserLectures({ reservation: data.reservation, wishlist: data.wishlist });
 
-    const userReservations = response.reservation.filter(
-      (lecture) => lecture.user_id === currentUserId,
-    );
-    const userWishlist = response.wishlist.filter((lecture) => lecture.user_id === currentUserId);
+        if (data.reservation.length > 0) {
+          const minStartTime = Math.min(
+            ...data.reservation.map((lec: LectureProps) => new Date(lec.startTime).getTime()),
+          );
+          const calculatedBaseDate = new Date(minStartTime);
+          calculatedBaseDate.setHours(0, 0, 0, 0);
+          setBaseDate(calculatedBaseDate);
 
-    if (userReservations.length > 0) {
-      const minStartTime = Math.min(
-        ...userReservations.map((lec) => new Date(lec.start_time).getTime()),
-      );
-      const calculatedBaseDate = new Date(minStartTime);
-      calculatedBaseDate.setHours(0, 0, 0, 0);
-      setBaseDate(calculatedBaseDate);
+          // Day n 매핑
+          const updatedReservations = data.reservation.map((lec: LectureProps) => {
+            const lectureDate = new Date(lec.startTime);
+            lectureDate.setHours(0, 0, 0, 0);
 
-      // Day n 매핑
-      const updatedReservations = userReservations.map((lec) => {
-        const lectureDate = new Date(lec.start_time);
-        lectureDate.setHours(0, 0, 0, 0);
+            const dayDiff = Math.floor(
+              (lectureDate.getTime() - calculatedBaseDate.getTime()) / (1000 * 60 * 60 * 24),
+            );
 
-        const dayDiff = Math.floor(
-          (lectureDate.getTime() - calculatedBaseDate.getTime()) / (1000 * 60 * 60 * 24),
-        );
-
-        return { ...lec, day: dayDiff + 1 };
-      });
-
-      //     setUserLectures({ reservation: userReservations, wishlist: userWishlist });
-      //   } catch (error) {
-      //     console.error('데이터 불러오기 실패: ', error);
-      //   }
-      // };
-
-      // fetchUserLectures();
-
-      setUserLectures({ reservation: updatedReservations, wishlist: userWishlist });
-    }
+            return { ...lec, day: dayDiff + 1 };
+          });
+          setUserLectures({ reservation: updatedReservations, wishlist: data.wishlist });
+        }
+      } catch (error) {
+        console.error('데이터 불러오기 실패: ', error);
+      }
+    };
+    fetchTimetable();
   }, []);
 
-  const fetchRecommandLectures = async (startTime: string, endTime: string) => {
-    console.log(startTime, endTime);
-    // try {
-    //   const response = await fetch(`/api/attendees/${currentUserId}/timetable/recommand`, {
-    //     method: 'POST',
-    //     headers: {
-    //       'Content-Type': 'application/json',
-    //     },
-    //     body: JSON.stringify({ start_time: startTime, end_time: endTime }),
-    //   });
+  const fetchTimeWish = async (startTime: string) => {
+    try {
+      // const response = await fetch(`/api/wishlist/lectures?startTime=${startTime}`);
+      // if (!response.ok) throw new Error('즐겨찾기 강의 데이터를 불러오는 데 실패했습니다.');
 
-    //   if (!response.ok) {
-    //     throw new Error('추천 강의 데이터를 불러오는 데 실패했습니다.');
-    //   }
+      // const data = await response.json();
+      const data = timeWishRes;
+      setTimeWish(data.responses);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
-    //   const data = await response.json();
-    setRecommandLectures(recommandLecturesDummy.data);
-    // } catch (error) {
-    //   console.error(error);
-    // }
+  const fetchTimeRecommand = async (startTime: string) => {
+    try {
+      // const response = await fetch(`/api/lectures/recommendations?startTime=${startTime}`);
+      // if (!response.ok) throw new Error('추천 강의 데이터를 불러오는 데 실패했습니다.');
+
+      // const data = await response.json();
+      const data = timeRecommandRes;
+      setRecommandLectures(data.lectures);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const handleEmptySlotClick = (day: number, start: string) => {
@@ -136,9 +149,8 @@ const TimetablePage = () => {
     selectedDate.setHours(Number(start.split(':')[0]), 0, 0, 0);
 
     const startTimeISO = selectedDate.toISOString();
-    const endTimeISO = new Date(selectedDate.getTime() + 60 * 60 * 1000).toISOString();
-
-    fetchRecommandLectures(startTimeISO, endTimeISO);
+    fetchTimeWish(startTimeISO);
+    fetchTimeRecommand(startTimeISO);
   };
 
   const filteredLectures = userLectures.reservation.filter(
@@ -156,7 +168,6 @@ const TimetablePage = () => {
   const occupiedSlots = new Set();
 
   const handleWishlistClick = () => {
-    setWishlist(wishlistResponse.response);
     setSelectedTime(null);
     setShowWishlist((prev) => !prev);
   };
@@ -192,7 +203,7 @@ const TimetablePage = () => {
 
               const lecture = filteredLectures.find(
                 (lecture) =>
-                  new Date(lecture.start_time).toLocaleTimeString('ko-KR', {
+                  new Date(lecture.startTime).toLocaleTimeString('ko-KR', {
                     hour: '2-digit',
                     minute: '2-digit',
                     hour12: false,
@@ -200,12 +211,12 @@ const TimetablePage = () => {
               );
 
               const rowSpan = lecture
-                ? (new Date(lecture.end_time).getTime() - new Date(lecture.start_time).getTime()) /
+                ? (new Date(lecture.endTime).getTime() - new Date(lecture.startTime).getTime()) /
                   (60 * 60 * 1000)
                 : 1;
 
               if (lecture) {
-                const occupiedTime = new Date(lecture.start_time);
+                const occupiedTime = new Date(lecture.startTime);
                 for (let i = 0; i < rowSpan; i++) {
                   const timeKey = occupiedTime.toLocaleTimeString('ko-KR', {
                     hour: '2-digit',
@@ -225,7 +236,7 @@ const TimetablePage = () => {
 
                   {lecture ? (
                     <div
-                      key={lecture.id}
+                      key={lecture.reservationId}
                       className="p-4 text-left cursor-pointer"
                       style={{
                         gridRow: `span ${rowSpan}`,
@@ -233,14 +244,14 @@ const TimetablePage = () => {
                         border: '1px solid #ccc',
                         borderBottom: rowSpan > 1 ? 'none' : '1px solid #ccc',
                       }}
-                      onClick={() => router.push(`/lecture/${lecture.lecture_id}`)}
+                      onClick={() => router.push(`/lecture/${lecture.lectureId}`)}
                     >
                       <p className="w-fit bg-gray-200 px-1">{lecture.location}</p>
                       <p>{lecture.title}</p>
                       <div className="flex justify-between">
-                        <p>{lecture.speaker}</p>
+                        <p>{lecture.speakerName}</p>
                         <p>
-                          인원수 {lecture.count} / {lecture.total}
+                          인원수 {lecture.currentReservation} / {lecture.capacity}
                         </p>
                       </div>
                     </div>
@@ -266,18 +277,18 @@ const TimetablePage = () => {
             <h3 className=" text-md font-semibold">즐찾 목록</h3>
             <div className="h-1/3 overflow-auto">
               <ul className="mt-2 border">
-                {userLectures.wishlist.map((lecture) => (
-                  <li key={lecture.id} className="p-2 border-b border-gray-200">
+                {timeWish.map((lecture, index) => (
+                  <li key={index} className="p-2 border-b border-gray-200">
                     <div className="flex items-center gap-2">
                       <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
                       <span className="text-xs">
-                        {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
                           hour: '2-digit',
                           minute: '2-digit',
                           hour12: false,
                         })}{' '}
                         -{' '}
-                        {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
                           hour: '2-digit',
                           minute: '2-digit',
                           hour12: false,
@@ -286,7 +297,7 @@ const TimetablePage = () => {
                     </div>
                     <span>{lecture?.title}</span>
                     <div className="flex justify-between w-full">
-                      <p>{lecture.speaker}</p>
+                      <p>{lecture.speakerName}</p>
                       <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
                         강의 신청
                       </button>
@@ -299,17 +310,17 @@ const TimetablePage = () => {
             <div className="h-1/2 overflow-auto">
               <ul className="mt-2 border">
                 {recommandLectures.map((lecture) => (
-                  <li key={lecture.lecture_id} className="p-2 border-b border-gray-200">
+                  <li key={lecture.id} className="p-2 border-b border-gray-200">
                     <div className="flex items-center gap-2">
                       <p className="bg-gray-200 w-fit px-2 dark:bg-gray-600">{lecture.location}</p>
                       <span className="text-xs">
-                        {new Date(lecture?.start_time).toLocaleTimeString('ko-KR', {
+                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
                           hour: '2-digit',
                           minute: '2-digit',
                           hour12: false,
                         })}{' '}
                         -{' '}
-                        {new Date(lecture?.end_time).toLocaleTimeString('ko-KR', {
+                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
                           hour: '2-digit',
                           minute: '2-digit',
                           hour12: false,
@@ -318,7 +329,7 @@ const TimetablePage = () => {
                     </div>
                     <span>{lecture?.title}</span>
                     <div className="flex justify-between w-full">
-                      <p>{lecture.speaker}</p>
+                      <p>{lecture.speakerName}</p>
                       <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
                         강의 신청
                       </button>
@@ -335,35 +346,39 @@ const TimetablePage = () => {
             <h3 className="text-md font-semibold">즐겨찾기 목록</h3>
             <div className="h-full overflow-auto">
               <ul className="mt-2 border">
-                {wishlist.map((lecture) => (
-                  <li key={lecture.id} className="p-2 border-b border-gray-200">
-                    <div className="flex items-center gap-2">
-                      <p className="bg-gray-200 text-sm w-fit px-2 dark:bg-gray-600">
-                        {lecture.location}
-                      </p>
-                      <span className="text-xs">
-                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}{' '}
-                        -{' '}
-                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}
-                      </span>
-                    </div>
-                    <span>{lecture?.lectureTitle}</span>
-                    <div className="flex justify-between w-full">
-                      <p>{lecture.speaker}</p>
-                      <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
-                        강의 신청
-                      </button>
-                    </div>
-                  </li>
-                ))}
+                {userLectures.wishlist.length > 0 ? (
+                  userLectures.wishlist.map((lecture) => (
+                    <li key={lecture.wishlistId} className="p-2 border-b border-gray-200">
+                      <div className="flex items-center gap-2">
+                        <p className="bg-gray-200 text-sm w-fit px-2 dark:bg-gray-600">
+                          {lecture.location}
+                        </p>
+                        <span className="text-xs">
+                          {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: false,
+                          })}{' '}
+                          -{' '}
+                          {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: false,
+                          })}
+                        </span>
+                      </div>
+                      <span>{lecture?.title}</span>
+                      <div className="flex justify-between w-full">
+                        <p>{lecture.speakerName}</p>
+                        <button className="bg-gray-600 text-white p-1 text-xs dark:bg-gray-500 cursor-pointer">
+                          강의 신청
+                        </button>
+                      </div>
+                    </li>
+                  ))
+                ) : (
+                  <p className="text-center p-4">즐겨찾기한 강의가 없습니다.</p>
+                )}
               </ul>
             </div>
           </div>

--- a/src/app/dummyData/timetable/getTimeWish.json
+++ b/src/app/dummyData/timetable/getTimeWish.json
@@ -1,0 +1,25 @@
+{
+  "responses": [
+    {
+      "category": "BACKEND",
+      "thumbnailUri": "uploads/lecture/thumbnail/123456789.jpg",
+      "title": "공간지능 혁신을 통한 온오프라인 통합 경험의 미래",
+      "contents": "Part 1: 온오프라인 경험을 연결하는 네이버 지도가 공간지능과 만나 제공하게 될 미래 모습을 소개합니다.",
+      "speakerName": "Cole Palmer",
+      "startTime": "2025-03-01T10:00:00",
+      "endTime": "2025-03-01T12:00:00",
+      "location": "온라인"
+    },
+    {
+      "category": "BACKEND",
+      "thumbnailUri": "uploads/lecture/thumbnail/123456789.jpg",
+      "title": "공간지능 혁신을 통한 온오프라인 통합 경험의 미래",
+      "contents": "Part 1: 온오프라인 경험을 연결하는 네이버 지도가 공간지능과 만나 제공하게 될 미래 모습을 소개합니다.",
+      "speakerName": "Cole Palmer",
+      "startTime": "2025-03-01T10:00:00",
+      "endTime": "2025-03-01T12:00:00",
+      "location": "온라인"
+    }
+  ],
+  "total": 2
+}

--- a/src/app/dummyData/timetable/getTimetable.json
+++ b/src/app/dummyData/timetable/getTimetable.json
@@ -1,67 +1,67 @@
 {
   "reservation": [
     {
-      "id": 1,
-      "user_id": 222,
-      "lecture_id": 1,
+      "reservationId": 1,
+      "userId": 222,
+      "lectureId": 1,
       "title": "강의 제목1",
-      "start_time": "2025-03-04T10:00:00",
-      "end_time": "2025-03-04T12:00:00",
+      "startTime": "2025-03-04T10:00:00",
+      "endTime": "2025-03-04T12:00:00",
+      "currentReservation": 12,
+      "capacity": 45,
       "location": "101호",
-      "speaker": "신짱구",
-      "count": 12,
-      "total": 45
+      "speakerName": "황효주"
     },
     {
-      "id": 2,
-      "user_id": 444,
-      "lecture_id": 1,
-      "title": "강의 제목1",
-      "start_time": "2025-03-04T10:00:00",
-      "end_time": "2025-03-04T12:00:00",
-      "location": "101호",
-      "speaker": "신짱구",
-      "count": 12,
-      "total": 45
+      "reservationId": 2,
+      "userId": 222,
+      "lectureId": 2,
+      "title": "강의 제목2",
+      "startTime": "2025-03-04T14:00:00",
+      "endTime": "2025-03-04T16:00:00",
+      "currentReservation": 5,
+      "capacity": 80,
+      "location": "102호",
+      "speakerName": "홍길동"
     },
     {
-      "id": 3,
-      "user_id": 222,
-      "lecture_id": 3,
+      "reservationId": 3,
+      "userId": 222,
+      "lectureId": 3,
       "title": "강의 제목3",
-      "start_time": "2025-03-06T09:00:00",
-      "end_time": "2025-03-06T11:00:00",
-      "location": "303호",
-      "speaker": "김철수",
-      "count": 28,
-      "total": 60
+      "startTime": "2025-03-05T09:00:00",
+      "endTime": "2025-03-05T11:00:00",
+      "currentReservation": 7,
+      "capacity": 20,
+      "location": "103호",
+      "speakerName": "고길동"
     }
   ],
 
   "wishlist": [
     {
-      "id": 1,
-      "user_id": 222,
-      "lecture_id": 2,
-      "title": "강의 제목2",
-      "start_time": "2025-03-05T14:00:00",
-      "end_time": "2025-03-05T16:00:00",
-      "location": "101호",
-      "speaker": "신짱구",
-      "count": 12,
-      "total": 45
+      "wishlistId": 1,
+      "userId": 222,
+      "lectureId": 4,
+      "title": "강의 제목4",
+      "startTime": "2025-03-04T14:00:00",
+      "endTime": "2025-03-04T16:00:00",
+      "currentReservation": 12,
+      "capacity": 45,
+      "location": "104호",
+      "speakerName": "신짱구"
     },
     {
-      "id": 2,
-      "user_id": 444,
-      "lecture_id": 2,
-      "title": "강의 제목2",
-      "start_time": "2025-03-05T14:00:00",
-      "end_time": "2025-03-05T16:00:00",
-      "location": "202호",
-      "speaker": "맹구",
-      "count": 14,
-      "total": 20
+      "wishlistId": 2,
+      "userId": 222,
+      "lectureId": 5,
+      "title": "강의 제목5",
+      "startTime": "2025-03-05T14:00:00",
+      "endTime": "2025-03-05T16:00:00",
+      "currentReservation": 12,
+      "capacity": 45,
+      "location": "105호",
+      "speakerName": "김철수"
     }
   ]
 }

--- a/src/app/dummyData/timetable/getTimetableRecommand.json
+++ b/src/app/dummyData/timetable/getTimetableRecommand.json
@@ -1,20 +1,24 @@
 {
-  "data": [
+  "lectures": [
     {
-      "lecture_id": 1,
+      "id": 1,
       "title": "추천강의제목1",
-      "start_time": "2025-03-05T10:00:00",
-      "end_time": "2025-03-05T11:00:00",
-      "location": "101호",
-      "speaker": "홍길동"
+      "category": "카테고리1",
+      "startTime": "2025-03-05T10:00:00",
+      "endTime": "2025-03-05T11:00:00",
+      "speakerName": "홍길동",
+      "speakerImageUri": "",
+      "location": "101호"
     },
     {
-      "lecture_id": 2,
+      "id": 2,
       "title": "추천강의제목2",
-      "start_time": "2025-03-05T13:00:00",
-      "end_time": "2025-03-05T15:00:00",
-      "location": "201호",
-      "speaker": "고길동"
+      "category": "카테고리2",
+      "startTime": "2025-03-05T10:00:00",
+      "endTime": "2025-03-05T11:00:00",
+      "speakerName": "홍길동",
+      "speakerImageUri": "",
+      "location": "102호"
     }
   ]
 }


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/timetable` → `dev`

<br/>

## ✅ 작업 내용

- 시간표 조회 시 전체 즐겨찾기 목록도 함께 받아오는 것으로 데이터 구조 변경
- 선택한 시간의 즐겨찾기 목록을 직접 필터링하는 방식에서, API를 통해 받아오는 방식으로 변경
- 기존 더미데이터의 구조를 새로운 응답 데이터 형식에 맞게 수정
- 응답 데이터의 변경되거나 추가된 필드명 → 관련된 props 수정
- 시간표 페이지에서 데이터를 렌더링하는 구조를 새로운 응답 형식에 맞게 수정
- 로그인 여부에 따라 시간표 조건부 렌더링

<br/>

## 🌠 이미지 첨부


<br/>

## ✏️ 앞으로의 과제

- 시간표 디자인 수정

<br/>

## 📌 이슈 링크

- [`feat/timetable`] #72  
