### PR TITLE
feat(ListCard): ListCard 컴포넌트 분리

### DIFF
--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -6,15 +6,14 @@ import timetableRes from '@/dummyData/timetable/getTimetable.json';
 import timeWishRes from '@/dummyData/timetable/getTimeWish.json';
 import timeRecommandRes from '@/dummyData/timetable/getTimetableRecommand.json';
 import DayTab from '@/_components/DayTab/DayTab';
-import WishButton from '@/_components/Wish/WishButton';
 import { PiListStar } from 'react-icons/pi';
-import { useLectureStore } from '@/_store/LectureList/useLectureStore';
 import {
   LectureProps,
   WishLectureProps,
   TimeWishProps,
   RecommandLectureProps,
 } from '@/_types/Timetable/Lecture.type';
+import ListCard from './timetableComponent/ListCard';
 
 const TimetablePage = () => {
   const [userLectures, setUserLectures] = useState<{
@@ -33,7 +32,6 @@ const TimetablePage = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true); // 임시로 항상 true
 
   const router = useRouter();
-  const { wishlist } = useLectureStore();
 
   useEffect(() => {
     const fetchTimetable = async () => {
@@ -265,89 +263,11 @@ const TimetablePage = () => {
           <div className="flex-1 px-6 pt-11 bg-[#F4F4F4] h-full dark:bg-gray-900">
             <h3 className="font-bold text-xl leading-[140%] pb-6">즐겨찾기 목록</h3>
             <div className="h-1/3 overflow-auto">
-              <ul className="flex flex-col gap-4">
-                {timeWish.map((lecture) => (
-                  <li key={lecture.lectureId} className="flex flex-col px-5 py-6 border bg-white">
-                    <div className="flex items-center gap-2">
-                      <p className="w-fit border rounded-sm border-[#91CAFF] text-[#1677FF] px-2 py-[1px] font-semibold text-sm leading-[140%]">
-                        {lecture.location}
-                      </p>
-                      <span className="font-semibold text-sm leading-[140%]">
-                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}{' '}
-                        -{' '}
-                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}
-                      </span>
-                    </div>
-                    <span className="pt-3 pb-2 font-bold text-lg leading-[140%]">
-                      {lecture?.title}
-                    </span>
-                    <p className="pb-4 font-medium text-base leading-[140%]">
-                      {lecture.speakerName}
-                    </p>
-                    <div className="flex justify-end items-center gap-2 w-full">
-                      <WishButton
-                        isWished={wishlist.has(lecture.lectureId)}
-                        itemId={lecture.lectureId}
-                        className="w-9 h-9"
-                      />
-                      <button className="bg-[#155DFC] rounded-lg text-white px-4 py-3 font-semibold text-sm leading-[140%] dark:bg-gray-500 cursor-pointer">
-                        강의 신청하기
-                      </button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              <ListCard lectureList={timeWish} />
             </div>
             <h3 className="pt-8 pb-6 font-bold text-xl leading-[140%]">공석 추천 목록</h3>
             <div className="h-1/2 overflow-auto">
-              <ul className="flex flex-col gap-4">
-                {recommandLectures.map((lecture) => (
-                  <li key={lecture.id} className="flex flex-col px-5 py-6 border bg-white">
-                    <div className="flex items-center gap-2">
-                      <p className="w-fit border rounded-sm border-[#91CAFF] text-[#1677FF] px-2 py-[1px] font-semibold text-sm leading-[140%]">
-                        {lecture.location}
-                      </p>
-                      <span className="font-semibold text-sm leading-[140%]">
-                        {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}{' '}
-                        -{' '}
-                        {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          hour12: false,
-                        })}
-                      </span>
-                    </div>
-                    <span className="pt-3 pb-2 font-bold text-lg leading-[140%]">
-                      {lecture?.title}
-                    </span>
-                    <p className="pb-4 font-medium text-base leading-[140%]">
-                      {lecture.speakerName}
-                    </p>
-                    <div className="flex justify-end items-center gap-2 w-full">
-                      <WishButton
-                        isWished={wishlist.has(lecture.id)}
-                        itemId={lecture.id}
-                        className="w-9 h-9"
-                      />
-                      <button className="bg-[#155DFC] rounded-lg text-white px-4 py-3 font-semibold text-sm leading-[140%] dark:bg-gray-500 cursor-pointer">
-                        강의 신청하기
-                      </button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              <ListCard lectureList={recommandLectures} />
             </div>
           </div>
         )}
@@ -356,53 +276,7 @@ const TimetablePage = () => {
           <div className="flex-1 px-6 pt-11 bg-[#F4F4F4] h-full dark:bg-gray-900">
             <h3 className="font-bold text-xl leading-[140%] pb-6">즐겨찾기 목록</h3>
             <div className="h-full overflow-auto">
-              <ul className="flex flex-col gap-4">
-                {userLectures.wishlist.length > 0 ? (
-                  userLectures.wishlist.map((lecture) => (
-                    <li
-                      key={lecture.wishlistId}
-                      className="flex flex-col px-5 py-6 border bg-white"
-                    >
-                      <div className="flex items-center gap-2">
-                        <p className="w-fit border rounded-sm border-[#91CAFF] text-[#1677FF] px-2 py-[1px] font-semibold text-sm leading-[140%]">
-                          {lecture.location}
-                        </p>
-                        <span className="font-semibold text-sm leading-[140%]">
-                          {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            hour12: false,
-                          })}{' '}
-                          -{' '}
-                          {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            hour12: false,
-                          })}
-                        </span>
-                      </div>
-                      <span className="pt-3 pb-2 font-bold text-lg leading-[140%]">
-                        {lecture?.title}
-                      </span>
-                      <p className="pb-4 font-medium text-base leading-[140%]">
-                        {lecture.speakerName}
-                      </p>
-                      <div className="flex justify-end items-center gap-2 w-full">
-                        <WishButton
-                          isWished={true}
-                          itemId={lecture.wishlistId}
-                          className="w-9 h-9"
-                        />
-                        <button className="bg-[#155DFC] rounded-lg text-white px-4 py-3 font-semibold text-sm leading-[140%] dark:bg-gray-500 cursor-pointer">
-                          강의 신청하기
-                        </button>
-                      </div>
-                    </li>
-                  ))
-                ) : (
-                  <p className="text-center p-4">즐겨찾기한 강의가 없습니다.</p>
-                )}
-              </ul>
+              <ListCard lectureList={userLectures.wishlist} />
             </div>
           </div>
         )}

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -9,56 +9,12 @@ import DayTab from '@/_components/DayTab/DayTab';
 import WishButton from '@/_components/Wish/WishButton';
 import { PiListStar } from 'react-icons/pi';
 import { useLectureStore } from '@/_store/LectureList/useLectureStore';
-
-interface LectureProps {
-  reservationId: number;
-  userId: number;
-  lectureId: number;
-  title: string;
-  startTime: string;
-  endTime: string;
-  currentReservation: number;
-  capacity: number;
-  location: string;
-  speakerName: string;
-  day?: number;
-}
-
-interface WishLectureProps {
-  wishlistId: number;
-  userId: number;
-  lectureId: number;
-  title: string;
-  startTime: string;
-  endTime: string;
-  currentReservation: number;
-  capacity: number;
-  location: string;
-  speakerName: string;
-}
-
-interface RecommandLectureProps {
-  id: number;
-  title: string;
-  category: string;
-  startTime: string;
-  endTime: string;
-  speakerName: string;
-  speakerImageUri: string;
-  location: string;
-}
-
-interface TimeWishProps {
-  lectureId: number;
-  category: string;
-  thumbnailUri: string;
-  title: string;
-  contents: string;
-  speakerName: string;
-  startTime: string;
-  endTime: string;
-  location: string;
-}
+import {
+  LectureProps,
+  WishLectureProps,
+  TimeWishProps,
+  RecommandLectureProps,
+} from '@/_types/Timetable/Lecture.type';
 
 const TimetablePage = () => {
   const [userLectures, setUserLectures] = useState<{

--- a/src/app/(route)/timetable/timetableComponent/ListCard.tsx
+++ b/src/app/(route)/timetable/timetableComponent/ListCard.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import WishButton from '@/_components/Wish/WishButton';
+import {
+  RecommandLectureProps,
+  TimeWishProps,
+  WishLectureProps,
+} from '@/_types/Timetable/Lecture.type';
+import { useLectureStore } from '@/_store/LectureList/useLectureStore';
+
+interface ListCardProps {
+  lectureList: (RecommandLectureProps | TimeWishProps | WishLectureProps)[];
+}
+
+const isWishLecture = (lecture: any): lecture is WishLectureProps => {
+  return 'wishlistId' in lecture;
+};
+
+const isRecommandLecture = (lecture: any): lecture is RecommandLectureProps => {
+  return 'id' in lecture;
+};
+
+const ListCard = ({ lectureList }: ListCardProps) => {
+  const { wishlist } = useLectureStore();
+
+  return (
+    <ul className="flex flex-col gap-4">
+      {lectureList.map((lecture) => (
+        <li
+          key={
+            isWishLecture(lecture)
+              ? lecture.wishlistId
+              : isRecommandLecture(lecture)
+                ? lecture.id
+                : lecture.lectureId
+          }
+          className="flex flex-col px-5 py-6 border bg-white"
+        >
+          <div className="flex items-center gap-2">
+            <p className="w-fit border rounded-sm border-[#91CAFF] text-[#1677FF] px-2 py-[1px] font-semibold text-sm leading-[140%]">
+              {lecture.location}
+            </p>
+            <span className="font-semibold text-sm leading-[140%]">
+              {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+              })}{' '}
+              -{' '}
+              {new Date(lecture?.endTime).toLocaleTimeString('ko-KR', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+              })}
+            </span>
+          </div>
+          <span className="pt-3 pb-2 font-bold text-lg leading-[140%]">{lecture?.title}</span>
+          <p className="pb-4 font-medium text-base leading-[140%]">{lecture.speakerName}</p>
+          <div className="flex justify-end items-center gap-2 w-full">
+            <WishButton
+              isWished={
+                isWishLecture(lecture)
+                  ? wishlist.has(lecture.lectureId)
+                  : isRecommandLecture(lecture)
+                    ? wishlist.has(lecture.id)
+                    : wishlist.has(lecture.lectureId)
+              }
+              itemId={
+                isWishLecture(lecture)
+                  ? lecture.lectureId
+                  : isRecommandLecture(lecture)
+                    ? lecture.id
+                    : lecture.lectureId
+              }
+              className="w-9 h-9"
+            />
+            <button className="bg-[#155DFC] rounded-lg text-white px-4 py-3 font-semibold text-sm leading-[140%] dark:bg-gray-500 cursor-pointer">
+              강의 신청하기
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ListCard;

--- a/src/app/(route)/timetable/timetableComponent/ListCard.tsx
+++ b/src/app/(route)/timetable/timetableComponent/ListCard.tsx
@@ -11,12 +11,12 @@ interface ListCardProps {
   lectureList: (RecommandLectureProps | TimeWishProps | WishLectureProps)[];
 }
 
-const isWishLecture = (lecture: any): lecture is WishLectureProps => {
-  return 'wishlistId' in lecture;
+const isWishLecture = (lecture: unknown): lecture is WishLectureProps => {
+  return typeof lecture === 'object' && lecture !== null && 'wishlistId' in lecture;
 };
 
-const isRecommandLecture = (lecture: any): lecture is RecommandLectureProps => {
-  return 'id' in lecture;
+const isRecommandLecture = (lecture: unknown): lecture is RecommandLectureProps => {
+  return typeof lecture === 'object' && lecture !== null && 'id' in lecture;
 };
 
 const ListCard = ({ lectureList }: ListCardProps) => {

--- a/src/app/_components/Wish/WishButton.tsx
+++ b/src/app/_components/Wish/WishButton.tsx
@@ -17,6 +17,7 @@ const WishButton = ({ isWished, itemId, className }: WishButtonProps) => {
         e.stopPropagation();
         toggleWish(itemId);
       }}
+      aria-label="즐겨찾기"
     >
       {isWished ? <FaStar color="#000" /> : <FaRegStar color="#000" />}
     </button>

--- a/src/app/_types/Timetable/Lecture.type.ts
+++ b/src/app/_types/Timetable/Lecture.type.ts
@@ -1,0 +1,40 @@
+interface BaseLectureProps {
+  title: string;
+  startTime: string;
+  endTime: string;
+  speakerName: string;
+  location: string;
+  category: string;
+}
+
+export interface RecommandLectureProps extends BaseLectureProps {
+  id: number;
+  speakerImageUri: string;
+}
+
+export interface TimeWishProps extends BaseLectureProps {
+  lectureId: number;
+  thumbnailUri: string;
+  contents: string;
+}
+
+interface TableBaseLectureProps {
+  userId: number;
+  lectureId: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+  currentReservation: number;
+  capacity: number;
+  location: string;
+  speakerName: string;
+}
+
+export interface LectureProps extends TableBaseLectureProps {
+  reservationId: number;
+  day?: number;
+}
+
+export interface WishLectureProps extends TableBaseLectureProps {
+  wishlistId: number;
+}


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/list-card` → `dev`

<br/>

## ✅ 작업 내용

- 시간표 페이지에서 전체 즐겨찾기 목록, 빈 시간 클릭 시 나오는 즐겨찾기 목록, 추천 강의 목록에서 동일한 UI로 반복되는 강의 목록 카드를 ListCard 컴포넌트로 분리
- 시간표 페이지에 관련된 타입 분리

<br/>

## 🌠 이미지 첨부


<br/>

## ✏️ 앞으로의 과제

- 내일 할 일을
- 적어주세요

<br/>

## 📌 이슈 링크

- [`feat/list-card`] #79 
