### PR TITLE
fix(main): 메인페이지 배경색 너비 문제 해결

### DIFF
--- a/src/app/(route)/layout.tsx
+++ b/src/app/(route)/layout.tsx
@@ -2,6 +2,7 @@ import '@/_styles/globals.css';
 import Header from '../_components/Header/Header';
 import getTheme from '../_utils/Header/getTheme.server';
 import KaKaoScript from '@/_components/Script/Login.script';
+import LayoutWrapper from '@/_components/LayoutWrapper';
 
 const RootLayout = async ({ children }: Readonly<{ children: React.ReactNode }>) => {
   const theme = await getTheme();
@@ -15,7 +16,7 @@ const RootLayout = async ({ children }: Readonly<{ children: React.ReactNode }>)
       >
         <KaKaoScript />
         <Header />
-        <div className="pt-[81px] max-w-7xl mx-auto my-0 relative">{children}</div>
+        <LayoutWrapper>{children}</LayoutWrapper>
       </body>
     </html>
   );

--- a/src/app/_components/LayoutWrapper.tsx
+++ b/src/app/_components/LayoutWrapper.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
+  const pathname = usePathname();
+  const isMainPage = pathname === '/';
+
+  return (
+    <div className={`${isMainPage ? 'w-full' : 'max-w-7xl mx-auto'} pt-[81px]`}>{children}</div>
+  );
+};
+
+export default LayoutWrapper;


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/main-width` → `dev`

<br/>

## ✅ 작업 내용

- 메인 페이지의 배경색이 전체 너비를 채우지 않는 문제를 해결하기 위해 `LayoutWrapper.tsx`를 추가하여 레이아웃을 분리
- `usePathname()`을 활용해 메인 페이지 여부 확인 후, 레이아웃 동적 변경
- 메인 페이지에서는 `w-full` 적용
- 다른 페이지에서는 기존 `max-w-7xl mx-auto` 레이아웃 유지

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| ![image](https://github.com/user-attachments/assets/17301c5a-6b68-44c5-82a9-d9d173ffbf63) | ![스크린샷 2025-03-20 오후 5 00 32](https://github.com/user-attachments/assets/505c0018-2de9-4171-878c-a44942f6c47b) |


<br/>

## ✏️ 앞으로의 과제

- 내일 할 일을
- 적어주세요

<br/>

## 📌 이슈 링크

- [`fix/main-width`] #82 