### PR TITLE
design(mainPage): api 연동 및 이미지 경로 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,9 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'dyns.co.kr',
+      },     {
+        protocol: 'https',
+        hostname: 'saerojinro-bucket.s3.ap-northeast-2.amazonaws.com',
       },
     ],
   },

--- a/src/app/(route)/(main)/mainComponent/SecSection.tsx
+++ b/src/app/(route)/(main)/mainComponent/SecSection.tsx
@@ -1,58 +1,22 @@
-'use client';
-import { useLectureStore } from '@/_store/LectureList/useLectureStore';
-import { ApiResponse } from '@/_types/Auth/auth.type';
 import SectionWrapper from './component/SectionWrapper';
-import ScrollWrapper from './component/ScrollWrapper';
-import { formatTime } from '@/_utils/Card/formatTime';
-import OptionList from './component/OptionList';
-import { useEffect, useState } from 'react';
-import Card from '@/_components/Card/Card';
+import SectionList from './component/SectionList';
+import { Lectures, temporaryLectures } from '@/_types/Lectures/lectures.type';
+import { getLectures } from '@/_utils/Main/getLectures';
 
-export interface LectureList {
-  id: number;
-  title: string;
-  category: string;
-  start_time: string;
-  end_time: string;
-  speakerName: string;
-  image: string;
-}
+const SecSection = async () => {
+  const DAY = 1;
+  const DATE = '2025-03';
+  let isLecturesFetched = false;
+  let lectures: Lectures = temporaryLectures;
 
-type GetDtoResPonse = ApiResponse<string>;
-export type LectureOption = 'all' | 12 | 13 | 14;
-
-const SecSection = () => {
-  const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-  const [lectureOption, setLectureOption] = useState<LectureOption>('all'); // 강의 옵션 상태
-  const [lectures, setLectures] = useState<LectureList[]>([]); // 강의 아이템 리스트[]
-  const { wishlist } = useLectureStore();
-
-  // lectureOption에 따른 API 요청
-  useEffect(() => {
-    (async () => {
-      try {
-        const path =
-          lectureOption === 'all'
-            ? '/api/test/lectures'
-            : `/api/test/lectures/date?day=${lectureOption}`;
-        const res = await fetch(`${BASE_URL}${path}`);
-
-        if (!res.ok) throw new Error(`API 요청 실패: ${res.status}`);
-
-        const dto: GetDtoResPonse = await res.json();
-
-        if (!dto.ok) throw new Error(`데이터 요청 실패: ${res.status}`);
-
-        if (dto.data) {
-          const lectures_ = JSON.parse(dto.data).data.lectures as LectureList[];
-          setLectures([...lectures_]);
-          console.log(lectures_);
-        }
-      } catch (err: unknown) {
-        console.error('api 요청 실패', err);
-      }
-    })();
-  }, [BASE_URL, lectureOption]);
+  try {
+    const data = await getLectures(DATE, DAY);
+    lectures = data;
+    isLecturesFetched = true;
+  } catch (error) {
+    console.error('강의 로드 실패: 테스트 데이터로 대체', error);
+    lectures = temporaryLectures;
+  }
 
   return (
     <>
@@ -67,33 +31,13 @@ const SecSection = () => {
             <h2 id="introduce-sections" className="text-[32px] font-bold">
               세션소개
             </h2>
-
-            {/* 옵션 버튼 리스트 */}
-            <OptionList
-              className="mt-6"
-              option={lectureOption}
-              ChangeOption={(option: LectureOption) => setLectureOption(option)}
+            {/* 세션 리스트 */}
+            <SectionList
+              startDay={DAY}
+              startDate={DATE}
+              initLectures={lectures}
+              isLecturesFetched={isLecturesFetched}
             />
-
-            {/* 강의 카드 리스트 */}
-            <ScrollWrapper>
-              {lectures.length === 0 && (
-                <div className="h-[222px]">강의 리스트를 불러오는 중...</div>
-              )}
-              {lectures.map((lecture, idx) => (
-                <Card
-                  key={idx}
-                  id={lecture.id}
-                  image={lecture.image}
-                  title={lecture.title}
-                  time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
-                  category={lecture.category}
-                  speakerName={lecture.speakerName}
-                  isWished={wishlist.has(lecture.id)}
-                  isProfile={false}
-                />
-              ))}
-            </ScrollWrapper>
           </div>
         </div>
       </SectionWrapper>

--- a/src/app/(route)/(main)/mainComponent/component/OptionList.tsx
+++ b/src/app/(route)/(main)/mainComponent/component/OptionList.tsx
@@ -1,16 +1,18 @@
 import ClickButton from '@/_components/ClickButton';
 import { HTMLAttributes, ReactNode } from 'react';
-import { LectureOption } from '../SecSection';
 
 interface Props {
-  option: LectureOption;
-  ChangeOption: (option: LectureOption) => void;
+  option: number;
+  startDay: number;
+  ChangeOption: (option: number) => void;
   className?: string;
+  limit?: number;
 }
 
-const OptionList = ({ option, ChangeOption, className }: Props) => {
-  const options: LectureOption[] = ['all', 12, 13, 14];
-  const getScript = (opt: LectureOption) => (opt === 'all' ? '전체' : `${opt}일`);
+const OptionList = ({ option, limit = 3, ChangeOption, className, startDay }: Props) => {
+  const options = [...Array(limit).keys()].map((idx) => startDay + idx);
+  const getScript = (opt: number) => `${opt}일`;
+
   return (
     <ul className={`flex gap-[0.5rem] select-none ${className}`}>
       {options.map((opt) => (

--- a/src/app/(route)/(main)/mainComponent/component/SectionList.tsx
+++ b/src/app/(route)/(main)/mainComponent/component/SectionList.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useLectureStore } from '@/_store/LectureList/useLectureStore';
+import { useEffect, useRef, useState } from 'react';
+import OptionList from './OptionList';
+import ScrollWrapper from './ScrollWrapper';
+import Card from '@/_components/Card/Card';
+import { formatTime } from '@/_utils/Card/formatTime';
+import { Lectures } from '@/_types/Lectures/lectures.type';
+import { getLectures } from '@/_utils/Main/getLectures';
+
+export interface LectureList {
+  id: number;
+  title: string;
+  category: string;
+  start_time: string;
+  end_time: string;
+  speakerName: string;
+  image: string;
+}
+
+interface Props {
+  startDay: number;
+  startDate: string;
+  initLectures: Lectures;
+  isLecturesFetched: boolean;
+}
+
+const SectionList = ({ startDay, startDate, initLectures, isLecturesFetched }: Props) => {
+  const [lectureOption, setLectureOption] = useState<number>(startDay); // 강의 옵션 상태
+  const [lectures, setLectures] = useState<Lectures>(initLectures);
+  const isInitialLoad = useRef<boolean>(isLecturesFetched); // 초기값 패치 여부
+  const { wishlist } = useLectureStore();
+
+  // lectureOption에 따른 API 요청
+  useEffect(() => {
+    if (isInitialLoad.current) {
+      isInitialLoad.current = false;
+      return; // 첫 요청은 서버에서 처리했으므로 무시함
+    }
+
+    (async () => {
+      try {
+        const data = await getLectures(startDate, lectureOption);
+        console.log(data);
+        setLectures(data);
+      } catch (error) {
+        console.error('강의 로드 실패: 테스트 데이터로 대체', error);
+      }
+    })();
+  }, [lectureOption, startDate]);
+
+  useEffect(() => {
+    console.log(lectures);
+  }, [lectures]);
+
+  return (
+    <>
+      <OptionList
+        className="mt-6"
+        startDay={startDay}
+        option={lectureOption}
+        ChangeOption={(option: number) => setLectureOption(option)}
+      />
+      {/* 강의 카드 리스트 */}
+      <ScrollWrapper>
+        {lectures.length === 0 && <div className="h-[222px]">강의 리스트를 불러오는 중...</div>}
+        {lectures.map((lecture, idx) => (
+          <Card
+            key={idx}
+            id={lecture.id}
+            image={lecture.thumbnailUri}
+            title={lecture.title}
+            time={`${formatTime(lecture.startTime)} ~ ${formatTime(lecture.endTime)}`}
+            category={lecture.category}
+            speakerName={lecture.speakerName}
+            isWished={wishlist.has(lecture.id)}
+            isProfile={false}
+          />
+        ))}
+      </ScrollWrapper>
+    </>
+  );
+};
+
+export default SectionList;

--- a/src/app/_types/Lectures/lectures.type.ts
+++ b/src/app/_types/Lectures/lectures.type.ts
@@ -1,0 +1,45 @@
+export type LecturesItem = {
+  id: number;
+  thumbnailUri: string;
+  startTime: string;
+  endTime: string;
+  title: string;
+  location: string;
+  speakerName: string;
+  category: string;
+};
+
+export type Lectures = LecturesItem[];
+
+export const temporaryLectures = [
+  {
+    id: 0,
+    thumbnailUri: '',
+    startTime: '',
+    endTime: '',
+    title: '',
+    location: '',
+    speakerName: '',
+    category: '',
+  },
+  {
+    id: 1,
+    thumbnailUri: '',
+    startTime: '',
+    endTime: '',
+    title: '',
+    location: '',
+    speakerName: '',
+    category: '',
+  },
+  {
+    id: 2,
+    thumbnailUri: '',
+    startTime: '',
+    endTime: '',
+    title: '',
+    location: '',
+    speakerName: '',
+    category: '',
+  },
+] as Lectures;

--- a/src/app/_utils/Main/getLectures.ts
+++ b/src/app/_utils/Main/getLectures.ts
@@ -1,0 +1,22 @@
+import { Lectures } from '@/_types/Lectures/lectures.type';
+
+export const getLectures = async (date: string, day: number): Promise<Lectures> => {
+  const BACK_URL = process.env.NEXT_PUBLIC_BACKEND_API;
+  const formattedDay = day.toString().padStart(2, '0');
+  const fullDate = `${date}-${formattedDay}`;
+  const endpoint = `${BACK_URL}/api/lectures/date?date=${fullDate}`;
+
+  const res = await fetch(endpoint);
+
+  if (!res.ok) {
+    throw new Error(`응답 실패: ${res.status}`);
+  }
+
+  const data = await res.json();
+
+  if (!data.lectures) {
+    throw new Error('lectures 필드가 존재하지 않습니다.');
+  }
+
+  return data.lectures as Lectures;
+};


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/mainPage` → `dev`

<br/>

## ✅ 작업 내용

- 메인 페이지 섹션2 일부 마진 수정
- 섹션2 강의 리스트 데이터 API 연동


<br/>

## 🌠 이미지 첨부

<img width="695" alt="image" src="https://github.com/user-attachments/assets/b675b865-0ccf-42ba-9bd7-d9b7a93da5f0" />

<br/>

## ✏️ 앞으로의 과제

- 강의 생성 API 연결
- 알림 API 연결

<br/>

## 📌 이슈 링크

- [design/mainPage #67]
