### PR TITLE
Feat[write-alarm]: 강의 생성 / 알림 기능 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tiptap/pm": "^2.11.5",
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
+        "event-source-polyfill": "^1.0.31",
         "immer": "^10.1.1",
         "lz-string": "^1.5.0",
         "next": "15.2.0",
@@ -5149,6 +5150,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
         "immer": "^10.1.1",
+        "lz-string": "^1.5.0",
         "next": "15.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6447,6 +6448,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/markdown-it": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
     "immer": "^10.1.1",
+    "lz-string": "^1.5.0",
     "next": "15.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tiptap/pm": "^2.11.5",
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
+    "event-source-polyfill": "^1.0.31",
     "immer": "^10.1.1",
     "lz-string": "^1.5.0",
     "next": "15.2.0",

--- a/src/app/(route)/write/util/upload.ts
+++ b/src/app/(route)/write/util/upload.ts
@@ -1,0 +1,135 @@
+'use client';
+import { ApiResponse } from '@/_types/Auth/auth.type';
+import { InputLectureFormData } from '@/_types/Write/write.type';
+
+const useUpload = () => {
+  const BACK_URL = process.env.NEXT_PUBLIC_BACKEND_ADMIN_API;
+  const path = {
+    thumbnail: BACK_URL + '/api/files/lecture/thumbnail',
+    profile: BACK_URL + '/api/files/lecture/thumbnail',
+    file: BACK_URL + '/api/files/lecture/materials',
+    submit: BACK_URL + '/api/lectures',
+  };
+
+  const getImageUID = async (
+    uri: string,
+    type: 'thumbnail' | 'profile',
+  ): Promise<ApiResponse<number>> => {
+    try {
+      const res = await fetch(`${path[type]}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          uri,
+        }),
+      });
+
+      if (!res.ok) throw new Error('응답 에러');
+
+      const data = (await res.json()) as { id: number };
+
+      if (typeof data.id !== 'number') throw new Error('타입 에러');
+
+      return {
+        ok: true,
+        data: data.id,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('getImageUID error:', message);
+      return {
+        ok: false,
+        error: `서버 오류 발생: ${message}`,
+      };
+    }
+  };
+
+  const getFileUID = async (file: File): Promise<ApiResponse<number>> => {
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch(`${path.file}`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!res.ok) throw new Error('응답 에러');
+
+      const data = (await res.json()) as { id: number };
+
+      if (typeof data.id !== 'number') throw new Error('타입 에러');
+
+      return {
+        ok: true,
+        data: data.id,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('getImageUID error:', message);
+      return {
+        ok: false,
+        error: `서버 오류 발생: ${message}`,
+      };
+    }
+  };
+
+  const submitLecture = async (dto: InputLectureFormData) => {
+    if (!dto.materialId) {
+      alert('파일이 비어있어요!');
+      return;
+    }
+
+    const speakerFilmography = JSON.stringify(dto.speakerFilmography);
+    let speakerPhotoId;
+    let thumbnailId;
+    let materialId;
+
+    try {
+      const res1 = await getImageUID(dto.thumbnailId, 'thumbnail');
+
+      if (!res1.ok || !res1.data) throw new Error('썸네일 추출 에러');
+
+      thumbnailId = res1.data;
+
+      const res2 = await getImageUID(dto.speakerPhotoId, 'profile');
+
+      if (!res2.ok || !res2.data) throw new Error('프로필 이미지 추출 에러');
+
+      speakerPhotoId = res2.data;
+
+      const res3 = await getFileUID(dto.materialId);
+
+      if (!res3.ok || !res3.data) throw new Error('파일 추출 에러');
+
+      materialId = res3.data;
+
+      const totalDto = { ...dto, speakerFilmography, speakerPhotoId, thumbnailId, materialId };
+
+      const res = await fetch(`${path.submit}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(totalDto),
+      });
+
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`강의 생성 에러: ${res.status} / ${errorText}`);
+      }
+
+      alert('강의 생성이 완료되었습니다.');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('서버 응답 오류:', message);
+      alert(`강의 생성 실패: ${message}`);
+    }
+  };
+
+  return { getImageUID, getFileUID, submitLecture };
+};
+
+export default useUpload;

--- a/src/app/_components/Header/Alarm/Alarm.tsx
+++ b/src/app/_components/Header/Alarm/Alarm.tsx
@@ -2,11 +2,15 @@
 import type { Alarm } from '@/_types/Header/Alarm.type';
 import ToggleModal from '@/_components/ToggleModal';
 import AlramIcon from '@/assets/Header/alarm.svg';
-import { CSSProperties, useState } from 'react';
+import { CSSProperties } from 'react';
 import AlarmList from './AlarmList';
 
+import useAlarmStore from '@/_store/Header/useAlarmStore';
+
 const Alarm = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const setIsOpen = useAlarmStore((store) => store.isOpen.actions.setIsOpen);
+  const isOpen = useAlarmStore((store) => store.isOpen.state.isOpen);
+  // const [isOpen, setIsOpen] = useState(false);
   const closeModal = () => setIsOpen(false);
   const openModal = () => setIsOpen(true);
   const ICON_WIDTH = 24;

--- a/src/app/_components/Header/Alarm/AlarmList.tsx
+++ b/src/app/_components/Header/Alarm/AlarmList.tsx
@@ -1,24 +1,30 @@
-import useAlarmStore, { AlarmView } from '@/_store/Header/useAlarmStore';
+import useAlarmStore from '@/_store/Header/useAlarmStore';
 import { getAlarmTime } from '@/_utils/Header/getAlarmTime';
-type ItemProps = Pick<AlarmView, 'title' | 'contents' | 'time'>;
+import { Alarm } from '@/_types/Header/Alarm.type';
+type ItemProps = Alarm;
 
 const AlarmList = () => {
-  const alarms = useAlarmStore((store) => store.state.alarms);
+  const alarms = useAlarmStore((store) => store.alarms.state.alarms);
   return (
     <ul className="p-6 flex flex-col">
-      {alarms.map(({ time, title, contents }, idx) => (
-        <AlarmItem key={`${title} + ${idx}`} time={time} title={title} contents={contents} />
+      {alarms.map(({ title, contents, createdAt }, idx) => (
+        <AlarmItem
+          key={`${title} + ${idx}`}
+          title={title}
+          contents={contents}
+          createdAt={createdAt}
+        />
       ))}
     </ul>
   );
 };
 
-const AlarmItem = ({ time, title, contents }: ItemProps) => {
+const AlarmItem = ({ createdAt, title, contents }: ItemProps) => {
   return (
     <li className="w-[448px] mt-6">
       <div className="flex justify-between">
         <span className="text-lg font-bold">{title}</span>
-        <span className="text-sm">{getAlarmTime(time)}</span>
+        <span className="text-sm">{getAlarmTime(createdAt)}</span>
       </div>
 
       <div className="mt-2">

--- a/src/app/_components/Header/HeaderNav/HeaderNav.tsx
+++ b/src/app/_components/Header/HeaderNav/HeaderNav.tsx
@@ -11,6 +11,7 @@ import useResize from '@/_hooks/nav/useResize';
 import { ReactNode, useEffect } from 'react';
 import { MenuButton } from './ETC';
 import useAuth from '@/_hooks/auth/useAuth';
+import useAlarm from '@/_hooks/nav/useAlarm';
 // import { UserRole } from '@/_types/Auth/auth.type';
 
 interface Props {
@@ -34,6 +35,7 @@ const HeaderNav = ({ children }: Props) => {
 
   // 리사이즈 훅
   useResize();
+  useAlarm();
 
   // web이면 메뉴 닫음
   useEffect(() => {

--- a/src/app/_hooks/nav/useAlarm.ts
+++ b/src/app/_hooks/nav/useAlarm.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect } from 'react';
+import { Alarm, ResponseAlarm } from '@/_types/Header/Alarm.type';
+import useAlarmStore from '@/_store/Header/useAlarmStore';
+import { wrapApiResponse } from '@/_utils/api/response';
+import { ApiResponse } from '@/_types/Auth/auth.type';
+import useAuthStore from '@/_store/auth/useAuth';
+// import { EventSourcePolyfill } from 'event-source-polyfill';
+
+const useAlarm = () => {
+  const loadInitAlarms = useAlarmStore((store) => store.alarms.actions.loadInitAlarms);
+  const isOpen = useAlarmStore((store) => store.isOpen.state.isOpen);
+  const accessToken = useAuthStore((store) => store.state.accessToken);
+  const role = useAuthStore((store) => store.state.role);
+
+  // 이벤트 스트림을 담기위함
+  // const [isInitialLoaded, setIsInitialLoaded] = useState(false); // 초기 데이터 상태 업뎃
+  // const eventRef = useRef<EventSource | null>(null);
+
+  const BACK_URL = process.env.NEXT_PUBLIC_BACKEND_API;
+  const URL = {
+    subscribeToAlarms: BACK_URL + '/api/notifications/subscribe',
+    fetchUserAlarms: BACK_URL + '/api/notifications/me',
+  };
+
+  const updateAlarm = useCallback(() => {
+    if (role !== 'user' || !accessToken) {
+      return Promise.resolve({ ok: false, error: '토큰 없음' } as ApiResponse<Alarm[]>);
+    }
+
+    return wrapApiResponse(
+      () =>
+        fetch(`${URL.fetchUserAlarms}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }),
+      (res) => res.json().then((dto: ResponseAlarm) => dto.contents),
+    );
+  }, [role, accessToken, URL.fetchUserAlarms]);
+
+  // 알림창을 열면 데이터 업데이트
+  useEffect(() => {
+    if (!isOpen) return;
+    (async () => {
+      const res = await updateAlarm();
+
+      if (!res.ok) {
+        if (res.error) console.error(res.error);
+        return;
+      }
+
+      if (!res.data) {
+        console.error('데이터 타입 불일치');
+        return;
+      }
+
+      loadInitAlarms(res.data);
+    })();
+  }, [isOpen, updateAlarm, loadInitAlarms]);
+};
+export default useAlarm;

--- a/src/app/_store/Header/useAlarmStore.ts
+++ b/src/app/_store/Header/useAlarmStore.ts
@@ -1,53 +1,91 @@
-import { createJSONStorage, persist } from 'zustand/middleware';
 import { Alarm } from '@/_types/Header/Alarm.type';
 import { BaseSlice } from '@/_types/store';
 import { create } from 'zustand';
 import { produce } from 'immer';
 
-export type AlarmView = Alarm & { time: string };
-
-export interface AlarmState {
-  alarms: AlarmView[];
+interface AlarmState {
+  alarms: Alarm[];
 }
 
-export interface AlarmActions {
+interface AlarmActions {
   addAlarm: (alarm: Alarm) => void;
   resetAlarm: () => void;
+  loadInitAlarms: (alarms: Alarm[]) => void;
 }
 
-type AlarmSlice = BaseSlice<AlarmState, AlarmActions>;
+interface IsSubscribeState {
+  isSubscribe: boolean;
+}
 
-const useAlarmStore = create<AlarmSlice>()(
-  persist(
-    (set) => ({
-      state: {
-        alarms: [],
+interface IsSubscribeActions {
+  setSubscribe: (state: boolean) => void;
+}
+
+interface IsOpenState {
+  isOpen: boolean;
+}
+
+interface IsOpenActions {
+  setIsOpen: (state: boolean) => void;
+}
+
+type AlarmSlice = {
+  alarms: BaseSlice<AlarmState, AlarmActions>;
+  isOpen: BaseSlice<IsOpenState, IsOpenActions>;
+  isSubscribe: BaseSlice<IsSubscribeState, IsSubscribeActions>;
+};
+
+const useAlarmStore = create<AlarmSlice>()((set) => ({
+  alarms: {
+    state: { alarms: [] },
+    actions: {
+      addAlarm(alarm) {
+        set(
+          produce((store: AlarmSlice) => {
+            store.alarms.state.alarms.push({ ...alarm });
+          }),
+        );
       },
-      actions: {
-        addAlarm(alarm) {
-          set(
-            produce((store: AlarmSlice) => {
-              store.state.alarms.push({
-                ...alarm,
-                time: new Date().toISOString(),
-              });
-            }),
-          );
-        },
-        resetAlarm() {
-          set(
-            produce((store: AlarmSlice) => {
-              store.state.alarms = [];
-            }),
-          );
-        },
+      resetAlarm() {
+        set(
+          produce((store: AlarmSlice) => {
+            store.alarms.state.alarms = [];
+          }),
+        );
       },
-    }),
-    {
-      name: 'alarm-storage',
-      storage: createJSONStorage(() => localStorage),
+      loadInitAlarms(alarms) {
+        set(
+          produce((store: AlarmSlice) => {
+            store.alarms.state.alarms = [...alarms];
+          }),
+        );
+      },
     },
-  ),
-);
+  },
+  isOpen: {
+    state: { isOpen: false },
+    actions: {
+      setIsOpen(state) {
+        set(
+          produce((store: AlarmSlice) => {
+            store.isOpen.state.isOpen = state;
+          }),
+        );
+      },
+    },
+  },
+  isSubscribe: {
+    state: { isSubscribe: false },
+    actions: {
+      setSubscribe(state) {
+        set(
+          produce((store: AlarmSlice) => {
+            store.isSubscribe.state.isSubscribe = state;
+          }),
+        );
+      },
+    },
+  },
+}));
 
 export default useAlarmStore;

--- a/src/app/_types/Header/Alarm.type.ts
+++ b/src/app/_types/Header/Alarm.type.ts
@@ -1,6 +1,9 @@
 export type Alarm = {
-  id: number;
-  lectureId: number;
   title: string;
   contents: string;
+  createdAt: string;
+};
+
+export type ResponseAlarm = {
+  contents: Array<Alarm>;
 };

--- a/src/app/_types/Write/write.type.ts
+++ b/src/app/_types/Write/write.type.ts
@@ -1,18 +1,25 @@
 export enum Category {
   BACKEND = 'BACKEND',
   FRONTEND = 'FRONTEND',
+  AI = 'AI',
+  DATA = 'DATA',
+  CLOUD = 'CLOUD',
   DEVOPS = 'DEVOPS',
+  UX_UI = 'UX_UI',
+  SEC = 'SEC',
+  PM = 'PM',
+  BLOCKCHAIN = 'BLOCKCHAIN',
   MOBILE = 'MOBILE',
 }
 
 export interface LectureFormData {
   title: string;
   contents: string;
-  thumbnail: number | null;
-  materialId: number | null;
+  thumbnailId: number;
+  materialId: number;
   maxCapacity: number;
-  start_time: string;
-  end_time: string;
+  startTime: string;
+  endTime: string;
   location: string;
   category: Category;
   speakerName: string;
@@ -20,11 +27,17 @@ export interface LectureFormData {
   speakerPosition: string;
   speakerIntroduction: string;
   speakerFilmography: string;
-  speakerPhotoId: number | null;
+  speakerPhotoId: number;
 }
 
 export type SendLectureFormData = LectureFormData;
 
-export type InputLectureFormData = Omit<LectureFormData, 'speakerFilmography'> & {
+export type InputLectureFormData = Omit<
+  LectureFormData,
+  'speakerFilmography' | 'speakerPhotoId' | 'thumbnailId' | 'materialId'
+> & {
   speakerFilmography: string[];
+  speakerPhotoId: string;
+  thumbnailId: string;
+  materialId: File | null;
 };

--- a/src/app/_utils/api/response.ts
+++ b/src/app/_utils/api/response.ts
@@ -1,0 +1,31 @@
+import { ApiResponse } from '@/_types/Auth/auth.type';
+
+const checkResponseStatus = async (res: Response): Promise<void> => {
+  if (!res.ok) {
+    if (res.status === 401) {
+      throw new Error('인증 실패: 토큰이 유효하지 않음');
+    } else if (res.status === 403) {
+      throw new Error('권한 없음');
+    } else if (res.status === 404) {
+      throw new Error('데이터를 찾을 수 없음');
+    } else {
+      const message = await res.text();
+      throw new Error(`서버 오류 (${res.status}): ${message}`);
+    }
+  }
+};
+
+export const wrapApiResponse = async <T>(
+  fetcher: () => Promise<Response>,
+  extractor: (res: Response) => Promise<T>,
+): Promise<ApiResponse<T>> => {
+  try {
+    const res = await fetcher();
+    await checkResponseStatus(res);
+    const data = await extractor(res);
+    return { ok: true, data };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다';
+    return { ok: false, error: message };
+  }
+};

--- a/src/app/api/auth/admin/route.ts
+++ b/src/app/api/auth/admin/route.ts
@@ -49,21 +49,21 @@ export async function POST(request: Request) {
 
     response.cookies.set('adminToken', 'admin', {
       httpOnly: true,
-      // secure: true,
+      secure: true,
       sameSite: 'strict',
       path: '/',
     });
 
     response.cookies.set('accessToken', userAccessToken, {
       httpOnly: true,
-      // secure: true, // HTTPS 환경에서만 전송
+      secure: true, // HTTPS 환경에서만 전송
       sameSite: 'strict',
       path: '/',
     });
 
     response.cookies.set('refreshToken', userRefreshToken, {
       httpOnly: true,
-      // secure: true,
+      secure: true,
       sameSite: 'strict',
       path: '/',
     });

--- a/src/app/api/auth/user/refresh/route.ts
+++ b/src/app/api/auth/user/refresh/route.ts
@@ -1,29 +1,11 @@
 import { ApiResponse, AuthRefreshResponse, UserRole } from '@/_types/Auth/auth.type';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-export async function GET(req: Request) {
-  const cookies = req.headers.get('cookie');
-
-  if (!cookies) {
-    return NextResponse.json<ApiResponse<AuthRefreshResponse>>(
-      { ok: false, error: 'No cookies found' },
-      { status: 401 },
-    );
-  }
-
-  const adminToken = cookies.includes('adminToken=')
-    ? cookies
-        .split('; ')
-        .find((row) => row.startsWith('adminToken='))
-        ?.split('=')[1]
-    : undefined;
-
-  const refreshToken = cookies.includes('refreshToken=')
-    ? cookies
-        .split('; ')
-        .find((row) => row.startsWith('refreshToken='))
-        ?.split('=')[1]
-    : undefined;
+export async function GET() {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+  const adminToken = cookieStore.get('adminToken')?.value;
 
   if (!refreshToken) {
     return NextResponse.json<ApiResponse<AuthRefreshResponse>>(
@@ -70,14 +52,14 @@ export async function GET(req: Request) {
 
     response.cookies.set('accessToken', accessToken, {
       httpOnly: true,
-      // secure: true,
+      secure: true,
       sameSite: 'strict',
       path: '/',
     });
 
     response.cookies.set('refreshToken', newRefreshToken, {
       httpOnly: true,
-      // secure: true,
+      secure: true,
       sameSite: 'strict',
       path: '/',
     });

--- a/src/app/api/auth/user/route.ts
+++ b/src/app/api/auth/user/route.ts
@@ -72,14 +72,14 @@ export async function POST(request: Request) {
 
     response.cookies.set('accessToken', userAccessToken, {
       httpOnly: true,
-      // secure: true, // HTTPS 환경에서만 전송
+      secure: true, // HTTPS 환경에서만 전송
       sameSite: 'strict',
       path: '/',
     });
 
     response.cookies.set('refreshToken', userRefreshToken, {
       httpOnly: true,
-      // secure: true,
+      secure: true,
       sameSite: 'strict',
       path: '/',
     });


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/api/write-alarm` → `dev`

<br/>

## ✅ 작업 내용

### Install
- add `lz-string // 강의 컨텐츠 데이터 압축`
- add `event-source-polyfill // 이벤트 스트림에 헤더 포함 가능한 라이브러리`

### 강의 생성 API 연결

- 현재 `/wrtie` 경로에 들어가면 로그인 유무 상관없이 강의 생성 가능함.
- 유의) `title`과 `email`은 반드시 독립적이여야 함.

### 알림 기능

- 현재 이벤트 스트림을 내려주는 엔드포인트가 없음
- 알림 창을 열었을 때 폴링처럼 모든 알림 데이터를 가져오게 임시 구현함
<br/>

## 🌠 이미지 첨부
`/write`
<img width="505" alt="image" src="https://github.com/user-attachments/assets/e827c5be-b277-42e5-b98e-37a68cb0daf8" />

알림
<img width="408" alt="image" src="https://github.com/user-attachments/assets/b3ea5b44-07bc-4070-b33b-41005937094c" />



<br/>

## ✏️ 앞으로의 과제

- 잘못된 강의 데이터 삭제 및 더미데이터 생성
- 메인 페이지 및 알림 컴포넌트 퍼블리싱

<br/>

## 📌 이슈 링크

- [`feat/api/write-alarm`  #87]