### PR TITLE
feat(lecture list): 강의 목록 API 연결

### DIFF
--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -13,16 +13,32 @@ const LectureListPage = () => {
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['ALL']);
 
+  const dateList = ['2025-03-01', '2025-03-02', '2025-03-03']; // 현재 데이터 들어있는 날짜로 임시
+  const dateToDayMap = dateList.reduce(
+    (acc, date, index) => {
+      acc[date] = `Day${index + 1}`;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  const dayToDateMap = Object.fromEntries(
+    Object.entries(dateToDayMap).map(([date, day]) => [day, date]),
+  );
+
   useEffect(() => {
-    fetchLectures();
+    fetchLectures(dayToDateMap[selectedDay]);
+  }, [selectedDay]);
+
+  useEffect(() => {
     fetchWishlist();
   }, []);
 
   const lectures: LectureListProps[] = lecturelist;
 
   const groupedByDay = groupByDay(lectures);
-  const days = Object.keys(groupedByDay);
-  const groupedByTime = selectedDay ? groupByTime(groupedByDay[selectedDay] || []) : {};
+  const selectedDate = dayToDateMap[selectedDay];
+  const groupedByTime = selectedDate ? groupByTime(groupedByDay[selectedDate] || []) : {};
 
   const filteredLectures: Record<string, LectureListProps[]> = selectedCategories.includes('ALL')
     ? groupedByTime
@@ -47,16 +63,18 @@ const LectureListPage = () => {
     return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
   }
 
-  console.log('filteredLectures:', filteredLectures);
-
   const categories = Array.from(new Set(lectures.map((lecture) => lecture.category)));
 
   return (
     <div className="px-10 py-16">
-      <DayTab days={days} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
+      <DayTab
+        days={Object.values(dateToDayMap)}
+        selectedDay={selectedDay}
+        onSelectDay={setSelectedDay}
+      />
       <div className="relative flex justify-between items-center h-10 mt-10">
         <h1 className="text-lg font-medium leading-[140%]">
-          {groupedByDay[selectedDay]?.length || 0} Sessions
+          {groupedByDay[selectedDate]?.length || 0} Sessions
         </h1>
         <button
           onClick={() => setIsFilterOpen(true)}
@@ -123,26 +141,30 @@ const LectureListPage = () => {
       </div>
 
       <div className="space-y-8">
-        {sortedTime.map((time) => (
-          <div key={time}>
-            <h2 className="text-2xl font-bold mt-8 mb-6">{time}</h2>
-            <ul className="flex flex-wrap gap-6">
-              {filteredLectures[time].map((lecture) => (
-                <Card
-                  key={lecture.id}
-                  id={lecture.id}
-                  image={lecture.thumbnailUri}
-                  title={lecture.title}
-                  category={lecture.category}
-                  time={`${formatTime(lecture.startTime)} ~ ${formatTime(lecture.endTime)}`}
-                  speakerName={lecture.speakerName}
-                  isWished={wishlist.has(lecture.id)}
-                  isProfile={false}
-                />
-              ))}
-            </ul>
-          </div>
-        ))}
+        {sortedTime.length > 0 ? (
+          sortedTime.map((time) => (
+            <div key={time}>
+              <h2 className="text-2xl font-bold mt-8 mb-6">{time}</h2>
+              <ul className="flex flex-wrap gap-6">
+                {filteredLectures[time].map((lecture) => (
+                  <Card
+                    key={lecture.id}
+                    id={lecture.id}
+                    image={lecture.thumbnailUri}
+                    title={lecture.title}
+                    category={lecture.category}
+                    time={`${formatTime(lecture.startTime)} ~ ${formatTime(lecture.endTime)}`}
+                    speakerName={lecture.speakerName}
+                    isWished={wishlist.has(lecture.id)}
+                    isProfile={false}
+                  />
+                ))}
+              </ul>
+            </div>
+          ))
+        ) : (
+          <p className="text-center text-gray-500 text-lg py-12">선택한 날짜에 강의가 없습니다.</p>
+        )}
       </div>
     </div>
   );

--- a/src/app/(route)/lecture-list/page.tsx
+++ b/src/app/(route)/lecture-list/page.tsx
@@ -47,6 +47,8 @@ const LectureListPage = () => {
     return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
   }
 
+  console.log('filteredLectures:', filteredLectures);
+
   const categories = Array.from(new Set(lectures.map((lecture) => lecture.category)));
 
   return (
@@ -129,10 +131,10 @@ const LectureListPage = () => {
                 <Card
                   key={lecture.id}
                   id={lecture.id}
-                  image={lecture.image}
+                  image={lecture.thumbnailUri}
                   title={lecture.title}
                   category={lecture.category}
-                  time={`${formatTime(lecture.start_time)} ~ ${formatTime(lecture.end_time)}`}
+                  time={`${formatTime(lecture.startTime)} ~ ${formatTime(lecture.endTime)}`}
                   speakerName={lecture.speakerName}
                   isWished={wishlist.has(lecture.id)}
                   isProfile={false}

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -38,11 +38,11 @@ const Card = ({
     >
       <div className="relative">
         <Image
-          src={image}
+          src={image || 'https://dyns.co.kr/wp-content/uploads/2024/04/placeholder-304.png'}
           alt={title}
           width={282}
           height={170}
-          className="w-full h-[170] object-cover"
+          className="w-full h-[170px] object-cover"
           priority
         />
         <WishButton isWished={isWished} itemId={id} className="absolute top-2 right-2" />

--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -51,7 +51,7 @@ const Card = ({
         <div className="w-full bg-white text-sm font-semibold leading-[140%] dark:bg-black dark:text-white">
           {time}
         </div>
-        <h3 className="text-[20px] font-bold leading-[140%] pt-1">{title}</h3>
+        <h3 className="text-[20px] font-bold leading-[140%] pt-1 h-15 overflow-hidden">{title}</h3>
 
         {!isProfile && (
           <div className="flex items-center pt-1">

--- a/src/app/_components/DayTab/groupBy.ts
+++ b/src/app/_components/DayTab/groupBy.ts
@@ -4,16 +4,16 @@ export const groupByDay = (lectures: LectureListProps[]) => {
   const grouped: Record<string, LectureListProps[]> = {};
 
   const sortedLectures = [...lectures].sort(
-    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
   );
 
   const uniqueDays = Array.from(
-    new Set(sortedLectures.map((lecture) => new Date(lecture.start_time).toDateString())),
+    new Set(sortedLectures.map((lecture) => new Date(lecture.startTime).toDateString())),
   );
 
   uniqueDays.forEach((day, index) => {
     grouped[`Day${index + 1}`] = sortedLectures.filter(
-      (lecture) => new Date(lecture.start_time).toDateString() === day,
+      (lecture) => new Date(lecture.startTime).toDateString() === day,
     );
   });
 
@@ -23,7 +23,7 @@ export const groupByDay = (lectures: LectureListProps[]) => {
 export const groupByTime = (lectures: LectureListProps[]) => {
   return lectures.reduce(
     (acc, lecture) => {
-      const timeStart = new Date(lecture.start_time).getHours().toString().padStart(2, '0') + ':00';
+      const timeStart = new Date(lecture.startTime).getHours().toString().padStart(2, '0') + ':00';
 
       if (!acc[timeStart]) acc[timeStart] = [];
       acc[timeStart].push(lecture);

--- a/src/app/_components/DayTab/groupBy.ts
+++ b/src/app/_components/DayTab/groupBy.ts
@@ -8,12 +8,14 @@ export const groupByDay = (lectures: LectureListProps[]) => {
   );
 
   const uniqueDays = Array.from(
-    new Set(sortedLectures.map((lecture) => new Date(lecture.startTime).toDateString())),
+    new Set(
+      sortedLectures.map((lecture) => new Date(lecture.startTime).toISOString().split('T')[0]),
+    ),
   );
 
-  uniqueDays.forEach((day, index) => {
-    grouped[`Day${index + 1}`] = sortedLectures.filter(
-      (lecture) => new Date(lecture.startTime).toDateString() === day,
+  uniqueDays.forEach((date) => {
+    grouped[date] = sortedLectures.filter(
+      (lecture) => new Date(lecture.startTime).toISOString().split('T')[0] === date,
     );
   });
 

--- a/src/app/_store/LectureList/useLectureStore.ts
+++ b/src/app/_store/LectureList/useLectureStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import lectureDataResponse from '@/dummyData/lecture-list/getLectureList.json';
 import wishlistDataResponse from '@/dummyData/wishlist/getWishlist.json';
 
 export interface LectureListProps {
@@ -29,7 +28,8 @@ interface LectureStore {
   toggleWish: (id: number) => void;
 }
 
-const lectureData = lectureDataResponse as { data: { lectures: LectureListProps[] } };
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_API;
+const date = '2025-03-01'; // 테스트용
 const wishlistData = wishlistDataResponse as { response: WishlistProps[] };
 
 export const useLectureStore = create<LectureStore>((set) => ({
@@ -37,24 +37,19 @@ export const useLectureStore = create<LectureStore>((set) => ({
   wishlist: new Set<number>(),
 
   fetchLectures: () => {
-    // const fetchLectures = async () => {
-    //   try {
-    //     const response = await fetch('/api/lectures');
-    //     if (!response.ok) {
-    //       throw new Error('네트워크 응답 오류');
-    //     }
-    //     const data = await response.json();
-    //     set({ lectures: data.lectures });
-    //   } catch (error) {
-    //     console.error('데이터 불러오기 실패: ', error);
-    //   }
-    // };
-
-    if (lectureData?.data?.lectures && Array.isArray(lectureData.data.lectures)) {
-      set({ lecturelist: lectureData.data.lectures });
-    } else {
-      console.error('강의 목록 데이터 구조가 예상과 다릅니다:', lectureData);
-    }
+    const fetchLectures = async () => {
+      try {
+        const response = await fetch(`${BASE_URL}/api/lectures/date?date=${date}`);
+        if (!response.ok) {
+          throw new Error('네트워크 응답 오류');
+        }
+        const data = await response.json();
+        set({ lecturelist: data.lectures });
+      } catch (error) {
+        console.error('데이터 불러오기 실패: ', error);
+      }
+    };
+    fetchLectures();
   },
 
   fetchWishlist: () => {

--- a/src/app/_store/LectureList/useLectureStore.ts
+++ b/src/app/_store/LectureList/useLectureStore.ts
@@ -5,10 +5,10 @@ export interface LectureListProps {
   id: number;
   title: string;
   category: string;
-  start_time: string;
-  end_time: string;
+  startTime: string;
+  endTime: string;
   speakerName: string;
-  image: string;
+  thumbnailUri: string;
 }
 
 export interface WishlistProps {

--- a/src/app/_store/LectureList/useLectureStore.ts
+++ b/src/app/_store/LectureList/useLectureStore.ts
@@ -23,33 +23,29 @@ export interface WishlistProps {
 interface LectureStore {
   lecturelist: LectureListProps[];
   wishlist: Set<number>;
-  fetchLectures: () => void;
+  fetchLectures: (date: string) => void;
   fetchWishlist: () => void;
   toggleWish: (id: number) => void;
 }
 
 const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_API;
-const date = '2025-03-01'; // 테스트용
 const wishlistData = wishlistDataResponse as { response: WishlistProps[] };
 
 export const useLectureStore = create<LectureStore>((set) => ({
   lecturelist: [] as LectureListProps[],
   wishlist: new Set<number>(),
 
-  fetchLectures: () => {
-    const fetchLectures = async () => {
-      try {
-        const response = await fetch(`${BASE_URL}/api/lectures/date?date=${date}`);
-        if (!response.ok) {
-          throw new Error('네트워크 응답 오류');
-        }
-        const data = await response.json();
-        set({ lecturelist: data.lectures });
-      } catch (error) {
-        console.error('데이터 불러오기 실패: ', error);
+  fetchLectures: async (date: string) => {
+    try {
+      const response = await fetch(`${BASE_URL}/api/lectures/date?date=${date}`);
+      if (!response.ok) {
+        throw new Error('네트워크 응답 오류');
       }
-    };
-    fetchLectures();
+      const data = await response.json();
+      set({ lecturelist: data.lectures });
+    } catch (error) {
+      console.error('데이터 불러오기 실패: ', error);
+    }
   },
 
   fetchWishlist: () => {


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/lecture-list-api` → `dev`

<br/>

## ✅ 작업 내용

- 강의 목록 API를 호출하여 데이터를 불러오도록 연동
- 강의 목록에서 시간대별 그룹화 및 렌더링 시 `NaN`이 표시되는 문제 해결
- 강의 데이터가 특정 날짜에 없는 경우에도 Day1,2,3 탭 유지하도록 날짜별 그룹화 로직 수정
- 카드 컴포넌트의 제목 영역이 차지하는 높이 고정

<br/>

## 🌠 이미지 첨부

| 변경 전 | 변경 후 |
|---|---|
| <img width="1512" alt="스크린샷 2025-03-21 오전 9 23 43" src="https://github.com/user-attachments/assets/f214098b-3444-4261-bdb0-256b96ce8702" /> | ![스크린샷](https://github.com/user-attachments/assets/f45a9ec1-bd2f-492b-b8b8-9b169b09ef2e) |

| 제목 높이 고정 전 | 제목 높이 고정 후 | 제목이 3줄이 넘어가도 두줄까지만 보인다 |
|---|---|---|
| <img width="614" alt="스크린샷 2025-03-21 오후 1 55 28" src="https://github.com/user-attachments/assets/079eb727-ad73-43be-89da-4a077a4f661e" /> | ![스크린샷 2025-03-21 오후 2 09 35](https://github.com/user-attachments/assets/436e2647-039c-479d-85ec-8d0158df6dcb) | ![스크린샷 2025-03-21 오후 2 33 14](https://github.com/user-attachments/assets/72088b6f-f5c0-4bc4-9b80-cc0098e6cbd7) |


<br/>

## ✏️ 앞으로의 과제

- 내일 할 일을
- 적어주세요

<br/>

## 📌 이슈 링크

- [`feat/lecture-list-api`] 
- #85 
- #88 
- #89 
- #90
