### PR TITLE
fix(lecture): 강의 상세페이지 로그인 여부 확인

### DIFF
--- a/src/app/(route)/lecture/[id]/page.tsx
+++ b/src/app/(route)/lecture/[id]/page.tsx
@@ -135,6 +135,13 @@ const LectureDetailPage = () => {
               itemId={Number(lectureId)}
               className="pt-1"
               iconClassName="w-6 h-6 text-[#015AFF] dark:text-[#014DD9]"
+              onBeforeToggle={() => {
+                if (!accessToken) {
+                  openLoginModal();
+                  return false;
+                }
+                return true;
+              }}
             />
           </div>
           <LectureReserveButton

--- a/src/app/(route)/lecture/component/QuestionSection.tsx
+++ b/src/app/(route)/lecture/component/QuestionSection.tsx
@@ -2,6 +2,7 @@ import { TextareaHTMLAttributes, useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import useHeaderStore from '@/_store/Header/useHeaderStore';
 import useAuthStore from '@/_store/auth/useAuth';
+import useLoginModalStore from '@/_store/modal/useLoginModalStore';
 import UserSVG from '@/assets/Lecture/Regular.svg';
 
 interface QuestionProps {
@@ -42,6 +43,7 @@ const QuestionSection = () => {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingContent, setEditingContent] = useState('');
   const showPopup = useHeaderStore((store) => store.popup.actions.showPopup);
+  const { open: openLoginModal } = useLoginModalStore();
 
   useEffect(() => {
     fetchQuestions();
@@ -63,6 +65,11 @@ const QuestionSection = () => {
   };
 
   const handleSubmit = async () => {
+    if (!accessToken) {
+      openLoginModal();
+      return;
+    }
+
     if (!text.trim()) return;
 
     try {


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/login-check`→ `dev`

<br/>

## ✅ 작업 내용

- 사전 질문 등록 시 로그인 여부 확인
- 강의 상세 페이지의 즐겨찾기 버튼 클릭 시 로그인 여부 확인

<br/>

## 🌠 이미지 첨부

<img width="1511" alt="스크린샷 2025-03-28 오전 3 00 27" src="https://github.com/user-attachments/assets/1f43f727-f518-454a-8acc-8113c4eb032f" />

<br/>

## ✏️ 앞으로의 과제

- 시간표 반영 문제 고치기

<br/>

## 📌 이슈 링크

- [`fix/login-check`] #128
