### PR TITLE
feat/design(adminAlarmPage): API 연동, UI 수정

### DIFF
--- a/src/app/(route)/admin/alarm/page.tsx
+++ b/src/app/(route)/admin/alarm/page.tsx
@@ -267,9 +267,10 @@ const NotificationPage = () => {
           ))}
         </div>
         <div className="w-[1122px] mt-4">
-          <button 
+          <button
             onClick={handleSendNotification}
-            className="flex items-center justify-center bg-blue-600 text-white px-6 py-2 hover:bg-blue-700 w-[92px] h-[48px] whitespace-nowrap">
+            className="flex items-center justify-center bg-blue-600 text-white px-6 py-2 hover:bg-blue-700 w-[92px] h-[48px] whitespace-nowrap"
+          >
             알림 전송
           </button>
         </div>


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/admin/alarm` → `dev`

<br/>

## ✅ 작업 내용

- API 연동하여 강의 목록 불러옴
- 알림 전송 기능 구현
- 디자인에 맞게 UI 수정

<br/>

## 🌠 이미지 첨부

<img src="https://github.com/user-attachments/assets/92c9fed2-4e80-4044-9c52-c6faa79c7e7c" width="50%" height="50%" />


<br/>

## ✏️ 앞으로의 과제

- 다크모드 구현
- 대시보드 API 연결 수정

<br/>

## 📌 이슈 링크

- [feat/admin/alarm #96 ](이슈 주소)
