### PR TITLE
design(lecture detail): 강의 상세페이지 반응형

### DIFF
--- a/src/app/(route)/lecture/[id]/page.tsx
+++ b/src/app/(route)/lecture/[id]/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Image from 'next/image';
 import { useTimetableStore } from '@/_store/timetable/useTimetableStore';
+import useAuthStore from '@/_store/auth/useAuth';
+import useLoginModalStore from '@/_store/modal/useLoginModalStore';
 import useDownload from '@/_hooks/download/download';
 import TextViewer from '@/_components/TextViewer/TextViewer';
 import QuestionSection from '../component/QuestionSection';
@@ -45,11 +47,14 @@ const LectureDetailPage = () => {
   const params = useParams();
   const lectureId = params.id as string;
   const [lecture, setLecture] = useState<LectureDetailProps>();
+  const accessToken = useAuthStore((store) => store.state.accessToken);
+  const { open: openLoginModal } = useLoginModalStore();
   const { toggleReservation, reservation, wishlist } = useTimetableStore();
   const isReserved = reservation.some((lec) => lec.lectureId === Number(lectureId));
   const isWished = wishlist.some((w) => w.lectureId === Number(lectureId));
   const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_API;
   const { downloadLectureFile } = useDownload();
+  const isLoggedIn = Boolean(accessToken);
 
   useEffect(() => {
     const fetchLectureDetail = async () => {
@@ -72,17 +77,17 @@ const LectureDetailPage = () => {
   const { dayText, timeText } = formatLectureDate(lecture.startTime, lecture.endTime);
 
   return (
-    <div className="w-full px-[40px] py-16 flex flex-col gap-[40px]  dark:bg-[#070A12]">
-      <header className="flex flex-col items-start self-stretch border-b border-b-[#E2E8F0] dark:border-b-[#161F2E] pb-10">
-        <div className="flex flex-col gap-3">
+    <div className="w-full px-[40px] py-16 flex flex-col gap-[40px] max-md:py-8 max-md:px-4 max-md:gap-8 dark:bg-[#070A12]">
+      <header className="flex flex-col items-start self-stretch border-b border-b-[#E2E8F0] dark:border-b-[#161F2E] pb-10 max-md:pb-8">
+        <div className="flex flex-col gap-3 max-md:gap-2">
           <time>
-            <span className="rounded-sm py-1 px-2 text-sm font-medium text-[#2F78FF] bg-[#E6EFFF] dark:text-[#0140B5] dark:bg-[#001046]">
+            <span className="rounded-sm py-1 px-2 text-sm font-medium text-[#2F78FF] bg-[#E6EFFF] dark:text-[#0140B5] dark:bg-[#001046] max-md:font-semibold max-md:text-xs">
               {dayText} | {timeText} | {lecture.location}
             </span>
           </time>
-          <h1 className="font-bold text-[32px]">{lecture.title}</h1>
+          <h1 className="font-bold text-[32px] max-md:text-2xl">{lecture.title}</h1>
           <div className="flex items-center gap-[8px]">
-            <span className="font-semibold text-base text-[#2F78FF] dark:text-[#0140B5]">
+            <span className="font-semibold text-base text-[#2F78FF] dark:text-[#0140B5] max-md:font-medium max-md:text-sm">
               #{lecture.category}
             </span>
           </div>
@@ -91,40 +96,59 @@ const LectureDetailPage = () => {
 
       <article>
         <TextViewer content={lecture.contents} />
+        <div className="hidden max-md:block max-md:mt-8">
+          <button
+            onClick={() => downloadLectureFile(lecture.speakerName, lecture.materialsId)}
+            disabled={!isLoggedIn}
+            className={`btn rounded-xs py-[6px] px-4 flex flex-row items-center justify-center gap-2 font-semibold text-base border 
+                ${isLoggedIn ? 'bg-white text-[#015AFF] border-[#015AFF] dark:bg-[#070A12] dark:text-[#014DD9] dark:border-[#003AA5] cursor-pointer' : 'bg-gray-200 text-gray-400 border-gray-300 dark:bg-[#1a1a1a] dark:text-gray-600 dark:border-gray-600 cursor-not-allowed'}
+            `}
+          >
+            <DownloadSvg />
+            download
+          </button>
+        </div>
       </article>
 
-      <article className="flex gap-6 self-stretch border-t border-t-[#E2E8F0] dark:border-t-[#161F2E] pt-10">
+      <article className="flex gap-6 max-md:gap-2 self-stretch max-md:items-center border-t border-t-[#E2E8F0] dark:border-t-[#161F2E] pt-10 max-md:pt-8">
         <div>
           <Image
             src={lecture.speakerPhotoUrl}
             alt={`${lecture.speakerName} 프로필 사진`}
             width={78}
             height={78}
-            className="w-[78px] h-[78px] rounded-sm object-cover"
+            className="w-[78px] h-[78px] rounded-sm object-cover max-md:w-[44px] max-md:h-[44px]"
           />
         </div>
-        <div className="flex flex-col flex-[1_0_0] gap-3">
+        <div className="flex flex-col flex-[1_0_0] gap-3 max-md:gap-1">
           <div className="flex item-center">
-            <span className="font-bold text-base mr-3">{lecture.speakerName}</span>
-            <span className="font-normal text-base">{lecture.speakerEmail}</span>
+            <span className="font-bold text-base mr-3 max-md:text-sm max-md:mr-1">
+              {lecture.speakerName}
+            </span>
+            <span className="font-normal text-base max-md:text-sm">{lecture.speakerEmail}</span>
           </div>
-          <p className="whitespace-pre-line font-normal text-base">{lecture.introduction}</p>
+          <p className="whitespace-pre-line font-normal text-base max-md:text-sm">
+            {lecture.introduction}
+          </p>
         </div>
       </article>
 
-      <div>
+      <div className="block max-md:hidden">
         <button
           onClick={() => downloadLectureFile(lecture.speakerName, lecture.materialsId)}
-          className="btn rounded-xs py-[6px] px-4 flex flex-row items-center justify-center gap-2 font-semibold text-base bg-white text-[#015AFF] border border-[#015AFF] dark:bg-[#070A12] dark:text-[#014DD9] dark:border-[#003AA5] cursor-pointer"
+          disabled={!isLoggedIn}
+          className={`btn rounded-xs py-[6px] px-4 flex flex-row items-center justify-center gap-2 font-semibold text-base border 
+                ${isLoggedIn ? 'bg-white text-[#015AFF] border-[#015AFF] dark:bg-[#070A12] dark:text-[#014DD9] dark:border-[#003AA5] cursor-pointer' : 'bg-gray-200 text-gray-400 border-gray-300 dark:bg-[#1a1a1a] dark:text-gray-600 dark:border-gray-600 cursor-not-allowed'}
+            `}
         >
           <DownloadSvg />
           download
         </button>
       </div>
 
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-6 max-md:gap-5">
         <QuestionSection />
-        <div className="flex flex-row gap-2 items-center mt-4">
+        <div className="flex flex-row gap-2 items-center mt-4 max-md:mt-3">
           <div className="flex flex-col justify-center items-center bg-[#F1F5F9] dark:bg-[#0D121E] w-12 h-12">
             <WishButton
               isWished={isWished}

--- a/src/app/(route)/lecture/component/QuestionSection.tsx
+++ b/src/app/(route)/lecture/component/QuestionSection.tsx
@@ -147,12 +147,12 @@ const QuestionSection = () => {
 
   return (
     <>
-      <h2 className="text-2xl font-bold self-stretch">사전 질문</h2>
-      <div className="flex gap-6">
+      <h2 className="text-2xl font-bold self-stretch max-md:text-xl">사전 질문</h2>
+      <div className="flex gap-6 max-md:gap-4">
         <div className="flex items-center justify-center resize-none w-full bg-[#F1F5F9] dark:bg-[#0D121E] px-4 rounded-xs">
           <Textarea
-            placeholder="강의 중 다뤄졌으면 하는 질문을 자유롭게 입력해주세요."
-            className="w-full border-none min-h-6 overflow-hidden resize-none border px-3 rounded-md focus:outline-none "
+            placeholder="강의 중 다뤄졌으면 하는 질문을 입력해주세요."
+            className="w-full border-none min-h-6 overflow-hidden resize-none border px-3 rounded-md focus:outline-none max-md:text-sm max-md:px-0"
             value={text}
             onChange={(e) => setText(e.target.value)}
             rows={1}
@@ -160,34 +160,34 @@ const QuestionSection = () => {
         </div>
         <button
           onClick={handleSubmit}
-          className="btn font-semibold text-base rounded-xs px-4 py-1 w-[62px] h-12 overflow-hidden cursor-pointer dark:bg-[#003AA5]"
+          className="btn font-semibold text-base max-md:text-sm rounded-xs whitespace-nowrap px-4 max-md:py-1.5 py-1 h-12 max-md:h-11 overflow-hidden cursor-pointer dark:bg-[#003AA5]"
         >
           등록
         </button>
       </div>
 
-      <div className="mt-6 flex flex-col gap-3">
+      <div className="mt-6 max-md:mt-5 flex flex-col gap-3">
         {questions.length === 0 ? (
           <p className="text-[#757575] text-sm font-medium text-center">등록된 질문이 없습니다.</p>
         ) : (
           questions.map((question) => (
             <div
               key={question.id}
-              className="flex justify-between items-start gap-6 self-stretch relative"
+              className="relative flex flex-col gap-2 md:flex-row md:items-start md:gap-6"
             >
-              <div className="absolute flex w-fit max-w-28 min-h-8 gap-1">
-                <div className="w-8 h-8 rounded-full overflow-hidden">
-                  {question.profileImage ? (
-                    <img
-                      src={question.profileImage}
-                      alt="프로필 이미지"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <UserSVG />
-                  )}
-                </div>
-                <div className="flex items-center">
+              <div className="flex justify-between">
+                <div className="flex items-center gap-1 min-w-20">
+                  <div className="w-8 h-8 rounded-xs overflow-hidden">
+                    {question.profileImage ? (
+                      <img
+                        src={question.profileImage}
+                        alt="프로필 이미지"
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <UserSVG />
+                    )}
+                  </div>
                   <span
                     className="font-semibold text-base truncate block max-w-20"
                     title={question.userName || 'user'}
@@ -195,9 +195,47 @@ const QuestionSection = () => {
                     {question.userName || 'user'}
                   </span>
                 </div>
+
+                {question.userName === myName && (
+                  <div className="md:absolute md:right-0 md:top-0 flex gap-2">
+                    {editingId === question.id ? (
+                      <>
+                        <button onClick={handleSave}>저장</button>
+                        <button
+                          onClick={() => {
+                            setEditingId(null);
+                            setEditingContent('');
+                          }}
+                        >
+                          취소
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => handleEditClick(question)}
+                          className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => {
+                            showPopup({
+                              contents: '정말 삭제하시겠습니까?',
+                              func: () => handleDelete(question.id),
+                            });
+                          }}
+                          className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
+                        >
+                          삭제
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
 
-              <div className="flex flex-1 items-center min-h-8 md:pt-0 md:mx-[calc(72px+24px+24px)]">
+              <div className="w-full md:pr-[100px]">
                 {editingId === question.id ? (
                   <Textarea
                     value={editingContent}
@@ -209,43 +247,6 @@ const QuestionSection = () => {
                   <p className="font-normal text-base">{question.content}</p>
                 )}
               </div>
-              {question.userName == myName && (
-                <div className="absolute h-[46px] right-0 flex gap-6 items-start">
-                  {editingId === question.id ? (
-                    <>
-                      <button onClick={handleSave}>저장</button>
-                      <button
-                        onClick={() => {
-                          setEditingId(null);
-                          setEditingContent('');
-                        }}
-                      >
-                        취소
-                      </button>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        onClick={() => handleEditClick(question)}
-                        className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
-                      >
-                        수정
-                      </button>
-                      <button
-                        onClick={() => {
-                          showPopup({
-                            contents: '정말 삭제하시겠습니까?',
-                            func: () => handleDelete(question.id),
-                          });
-                        }}
-                        className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
-                      >
-                        삭제
-                      </button>
-                    </>
-                  )}
-                </div>
-              )}
             </div>
           ))
         )}


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/lecture-detail` → `dev`

<br/>

## ✅ 작업 내용

- 강의 상세페이지 반응형 적용
- 로그인 안한 상태에서 강의 자료 다운로드 disable
<br/>

## 🌠 이미지 첨부

![스크린샷 2025-03-28 오후 2 56 45](https://github.com/user-attachments/assets/a6102e7b-a9c6-4f15-8c5c-289b478bc961)


<br/>

## ✏️ 앞으로의 과제

- 강의 목록 반응형
- 시간표 반응형

<br/>

## 📌 이슈 링크

- [`design/lecture-detail`] #137 
