### PR TITLE
fix(alarm): 액세스 토큰 권한이 없을 때 알림 요청하는 오류 픽스

### DIFF
--- a/src/app/_hooks/nav/useAlarm.ts
+++ b/src/app/_hooks/nav/useAlarm.ts
@@ -14,6 +14,7 @@ const useAlarm = () => {
   };
 
   const accessToken = useAuthStore((store) => store.state.accessToken);
+  const setAuth = useAuthStore((store) => store.actions.setAuth);
   const role = useAuthStore((store) => store.state.role);
   const isOpen = useAlarmStore((store) => store.isOpen.state.isOpen);
   const isNewMessage = useAlarmStore((store) => store.isNewMessage.state.isNewMessage);
@@ -49,6 +50,7 @@ const useAlarm = () => {
 
     try {
       const res = await getNotifications();
+
       if (!res.data) throw new Error('데이터가 존재하지 않습니다');
 
       const data = res.data;
@@ -71,8 +73,9 @@ const useAlarm = () => {
       if (!isOpen) setNewMessageState(true);
     } catch (err) {
       console.error(err);
+      setAuth(null, 'guest');
     }
-  }, [accessToken, role, isOpen, loadInitAlarms, getNotifications, setNewMessageState]);
+  }, [accessToken, role, isOpen, loadInitAlarms, getNotifications, setNewMessageState, setAuth]);
 
   //#endregion
 


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/alarm` → `dev`

<br/>

## ✅ 작업 내용

- 액세스 토큰의 유효성이 다 끝났음에도 불구하고, 계속 알림을 신청하는 에러가 있었음.
- 알림을 실패 했을 때 액세스 토큰을 삭제하게 구현하여 이를 개선함

<br/>

## 🌠 이미지 첨부

<br/>

## ✏️ 앞으로의 과제


<br/>

## 📌 이슈 링크

- [fix/alarm #129]
