### PR TITLE
fix(adminDashboardPage) : API 연결 수정

### DIFF
--- a/src/app/(route)/admin/page.tsx
+++ b/src/app/(route)/admin/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import useAuthStore from '@/_store/auth/useAuth';
 import { useState, useEffect, useMemo } from 'react';
 import '../../_styles/admin.css';
 
@@ -24,22 +25,27 @@ const AdminDashboard = () => {
   const [lecturesRaw, setLecturesRaw] = useState<Lecture[]>([]);
   const [timeRank, setTimeRank] = useState<TimeRank[]>([]);
 
+  const accessToken = useAuthStore((store) => store.state.accessToken);
+  const role = useAuthStore((store) => store.state.role);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch('https://admin.saerojinro.site/api/dashboard');
+        const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_ADMIN_API}/api/dashboard`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
         if (!response.ok) throw new Error('API 호출 실패');
         const data = await response.json();
-
+        console.log(data);
         setLecturesRaw(data.lectureHighRank.concat(data.lectureLowRank)); // 전체 데이터를 한번에 받는다고 가정
         setTimeRank(data.timeRank.slice(0, 10));
       } catch (error) {
         console.error('데이터 로딩 실패:', error);
       }
     };
-
-    fetchData();
-  }, []);
+    if (role === 'admin') fetchData();
+  }, [accessToken, role]);
 
   const toggleSort = () => {
     setIsLowToHigh((prev) => !prev);


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/admin/dashboard` → `dev`

<br/>

## ✅ 작업 내용

- 어드민 대시보드 API 연동에 accessToken 추가

<br/>

## 🌠 이미지 첨부

<img src="https://github.com/user-attachments/assets/28642053-4bc8-4ac1-903b-b7298b2c8474" width="50%" height="50%"/>

<img src="https://github.com/user-attachments/assets/1dc109d5-4931-4403-b907-00a7aca725f8" width="50%" height="50%"/>

<br/>

## ✏️ 앞으로의 과제

- 다크 모드 적용

<br/>

## 📌 이슈 링크

- [feat/admin/dashboard #100 ](이슈 주소)
