### PR TITLE
fix(lecture-list): 강의 리스트 페이지 시간표 페이지 동기화

### DIFF
--- a/src/app/(route)/lecture-list/component/list.tsx
+++ b/src/app/(route)/lecture-list/component/list.tsx
@@ -11,6 +11,7 @@ import XSvg from '@/assets/LectureList/X.svg';
 import ResetSvg from '@/assets/LectureList/arrow.svg';
 
 import { useRouter, useSearchParams } from 'next/navigation';
+import useAuthStore from '@/_store/auth/useAuth';
 
 const LectureListPage = ({
   initDay,
@@ -24,6 +25,16 @@ const LectureListPage = ({
   const [selectedDay, setSelectedDay] = useState<string>(initDay);
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(initCategories ?? ['ALL']);
+
+  /** zustand */
+  const accessToken = useAuthStore((store) => store.state.accessToken);
+  const role = useAuthStore((store) => store.state.role);
+  const { fetchTimetable } = useTimetableStore();
+
+  /** timetable ynchronization */
+  useEffect(() => {
+    if (accessToken || role === 'user') fetchTimetable();
+  }, [accessToken, role, fetchTimetable]);
 
   const dateList = ['2025-04-01', '2025-04-02', '2025-04-03'];
   const dateToDayMap = dateList.reduce(


### PR DESCRIPTION
## 🚀 반영 브랜치

``fix/lecture-list`` → `dev`

<br/>

## ✅ 작업 내용

- 신청한 강의 상태 반영 버그 해결
- 강의 리스트 진입시 시간표 데이터를 동기화하도록 개선

`lecture-list/componenet/list.tsx`
```ts

 /** zustand */
  const accessToken = useAuthStore((store) => store.state.accessToken);
  const role = useAuthStore((store) => store.state.role);
  const { fetchTimetable } = useTimetableStore();

  /** timetable ynchronization */
  useEffect(() => {
    if (accessToken || role === 'user') fetchTimetable();
  }, [accessToken, role, fetchTimetable]);

```

<br/>

## 🌠 이미지 첨부

## ✏️ 앞으로의 과제


<br/>

## 📌 이슈 링크

- [`fix/lecture-list` #157]
