### PR TITLE
design(lecture,list,timetable): 디자인 QA 반영

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'img1.kakaocdn.net',
       },
+      {
+        protocol: 'https',
+        hostname: 'k.kakaocdn.net',
+      },
     ],
   },
 };

--- a/src/app/(route)/lecture-list/component/list.tsx
+++ b/src/app/(route)/lecture-list/component/list.tsx
@@ -118,7 +118,7 @@ const LectureListPage = ({
         onSelectDay={setSelectedDay}
       />
       <div className="relative flex justify-between items-center h-10 mt-10 max-md:mt-5">
-        <h1 className="text-lg font-medium leading-[140%] max-md:text-sm">
+        <h1 className="text-[#212121] text-lg font-medium leading-[140%] max-md:text-sm">
           <span className="text-[#015AFF] dark:text-[#014DD9]">
             {groupedByDay[selectedDate]?.length || 0}
           </span>{' '}
@@ -133,7 +133,7 @@ const LectureListPage = ({
 
         {isFilterOpen && (
           <div
-            className="absolute top-10 right-0 z-10 max-md:fixed max-md:inset-0 max-md:top-16 max-md:bg-[#000000B2]"
+            className="absolute top-10 right-0 z-10 rounded-sm max-md:fixed max-md:inset-0 max-md:top-16 max-md:bg-[#000000B2]"
             onClick={() => setIsFilterOpen(false)}
           >
             <div
@@ -202,7 +202,9 @@ const LectureListPage = ({
         {sortedTime.length > 0 ? (
           sortedTime.map((time) => (
             <div key={time}>
-              <h2 className="text-2xl font-bold mt-8 mb-4 max-md:text-lg max-md:my-4">{time}</h2>
+              <h2 className="text-[#212121] text-2xl font-bold mt-8 mb-4 max-md:text-lg max-md:my-4">
+                {time}
+              </h2>
               <ul className="flex flex-wrap gap-6 max-md:gap-3">
                 {filteredLectures[time].map((lecture) => (
                   <Card

--- a/src/app/(route)/lecture/[id]/page.tsx
+++ b/src/app/(route)/lecture/[id]/page.tsx
@@ -85,7 +85,9 @@ const LectureDetailPage = () => {
               {dayText} | {timeText} | {lecture.location}
             </span>
           </time>
-          <h1 className="font-bold text-[32px] max-md:text-2xl">{lecture.title}</h1>
+          <h1 className="text-[#212121] dark:text-white font-bold text-[32px] max-md:text-2xl">
+            {lecture.title}
+          </h1>
           <div className="flex items-center gap-[8px]">
             <span className="font-semibold text-base text-[#2F78FF] dark:text-[#0140B5] max-md:font-medium max-md:text-sm">
               #{lecture.category}
@@ -153,7 +155,7 @@ const LectureDetailPage = () => {
             <WishButton
               isWished={isWished}
               itemId={Number(lectureId)}
-              className="pt-1"
+              className="w-12 h-12"
               iconClassName="w-6 h-6 text-[#015AFF] dark:text-[#014DD9]"
               onBeforeToggle={() => {
                 if (!accessToken) {

--- a/src/app/(route)/lecture/component/QuestionSection.tsx
+++ b/src/app/(route)/lecture/component/QuestionSection.tsx
@@ -11,6 +11,7 @@ interface QuestionProps {
   userName: string;
   profileImage: string;
   userId?: number;
+  isWriter: boolean;
 }
 
 // 크기 자동 조절 textArea
@@ -37,13 +38,14 @@ const QuestionSection = () => {
   const lectureId = params.id as string;
   const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_API;
   const accessToken = useAuthStore((store) => store.state.accessToken);
-  const myName = useAuthStore((store) => store.state.name);
   const [text, setText] = useState('');
   const [questions, setQuestions] = useState<QuestionProps[]>([]);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingContent, setEditingContent] = useState('');
   const showPopup = useHeaderStore((store) => store.popup.actions.showPopup);
   const { open: openLoginModal } = useLoginModalStore();
+  const [multilineMap, setMultilineMap] = useState<Record<number, boolean>>({});
+  const contentRefs = useRef<Record<number, HTMLParagraphElement | null>>({});
 
   useEffect(() => {
     fetchQuestions();
@@ -51,7 +53,13 @@ const QuestionSection = () => {
 
   const fetchQuestions = async () => {
     try {
-      const response = await fetch(`${BASE_URL}/api/questions/lectures/${lectureId}`);
+      const response = await fetch(`${BASE_URL}/api/questions/lectures/${lectureId}`, {
+        method: 'GET',
+        headers: {
+          ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+        },
+      });
+
       if (!response.ok) {
         throw new Error('네트워크 응답 오류');
       }
@@ -59,6 +67,19 @@ const QuestionSection = () => {
       console.log(data);
       const questionList: QuestionProps[] = data.questionList;
       setQuestions(questionList);
+
+      requestAnimationFrame(() => {
+        const newMap: Record<number, boolean> = {};
+        questionList.forEach((q) => {
+          const el = contentRefs.current[q.id];
+          if (el) {
+            const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+            const lines = el.clientHeight / lineHeight;
+            newMap[q.id] = lines >= 2;
+          }
+        });
+        setMultilineMap(newMap);
+      });
     } catch (error) {
       console.error('데이터 불러오기 실패: ', error);
     }
@@ -149,10 +170,10 @@ const QuestionSection = () => {
     <>
       <h2 className="text-2xl font-bold self-stretch max-md:text-xl">사전 질문</h2>
       <div className="flex gap-6 max-md:gap-4">
-        <div className="flex items-center justify-center resize-none w-full bg-[#F1F5F9] dark:bg-[#0D121E] px-4 rounded-xs">
+        <div className="flex items-center justify-center resize-none w-full bg-[#F1F5F9] dark:bg-[#0D121E] rounded-xs focus-within:outline outline-[#015AFF] focus-within:bg-white dark:focus-within:outline-[#003AA5] dark:focus-within:bg-[#070A12]">
           <Textarea
-            placeholder="강의 중 다뤄졌으면 하는 질문을 입력해주세요."
-            className="w-full border-none min-h-6 overflow-hidden resize-none border px-3 rounded-md focus:outline-none max-md:text-sm max-md:px-0"
+            placeholder="사전 질문을 작성해 주세요."
+            className="text-[#212121] dark:text-white w-full border-none min-h-6 overflow-hidden resize-none border px-4 rounded-md focus:outline-none max-md:text-sm max-md:px-0"
             value={text}
             onChange={(e) => setText(e.target.value)}
             rows={1}
@@ -160,7 +181,7 @@ const QuestionSection = () => {
         </div>
         <button
           onClick={handleSubmit}
-          className="btn font-semibold text-base max-md:text-sm rounded-xs whitespace-nowrap px-4 max-md:py-1.5 py-1 h-12 max-md:h-11 overflow-hidden cursor-pointer dark:bg-[#003AA5]"
+          className="btn font-semibold text-base max-md:text-sm rounded-xs whitespace-nowrap px-4 max-md:py-1.5 py-1 h-12 max-md:h-11 overflow-hidden cursor-pointer bg-[#015AFF] dark:bg-[#003AA5]"
         >
           등록
         </button>
@@ -173,7 +194,9 @@ const QuestionSection = () => {
           questions.map((question) => (
             <div
               key={question.id}
-              className="relative flex flex-col gap-2 md:flex-row md:items-start md:gap-6"
+              className={`relative flex flex-col gap-2 md:flex-row md:gap-6 ${
+                multilineMap[question.id] ? 'md:items-start' : 'md:items-center'
+              }`}
             >
               <div className="flex justify-between">
                 <div className="flex items-center gap-1 min-w-20">
@@ -189,14 +212,14 @@ const QuestionSection = () => {
                     )}
                   </div>
                   <span
-                    className="font-semibold text-base truncate block max-w-20"
+                    className="font-semibold text-base text-[#212121] dark:text-white truncate block max-w-20"
                     title={question.userName || 'user'}
                   >
                     {question.userName || 'user'}
                   </span>
                 </div>
 
-                {question.userName === myName && (
+                {question.isWriter && (
                   <div className="md:absolute md:right-0 md:top-0 flex gap-2">
                     {editingId === question.id ? (
                       <>
@@ -214,7 +237,7 @@ const QuestionSection = () => {
                       <>
                         <button
                           onClick={() => handleEditClick(question)}
-                          className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
+                          className="cursor-pointer font-medium text-base text-[#424242] dark:text-[#CAD5E2]"
                         >
                           수정
                         </button>
@@ -225,7 +248,7 @@ const QuestionSection = () => {
                               func: () => handleDelete(question.id),
                             });
                           }}
-                          className="cursor-pointer font-medium text-base dark:text-[#CAD5E2]"
+                          className="cursor-pointer font-medium text-base text-[#424242] dark:text-[#CAD5E2]"
                         >
                           삭제
                         </button>
@@ -244,7 +267,14 @@ const QuestionSection = () => {
                     className="resize-none w-full overflow-hidden rounded-[4px] border border-solid border-[#015AFF] p-2"
                   />
                 ) : (
-                  <p className="font-normal text-base">{question.content}</p>
+                  <p
+                    className="font-normal text-base text-[#212121] dark:text-white"
+                    ref={(el: HTMLParagraphElement | null) => {
+                      contentRefs.current[question.id] = el;
+                    }}
+                  >
+                    {question.content}
+                  </p>
                 )}
               </div>
             </div>

--- a/src/app/(route)/timetable/page.tsx
+++ b/src/app/(route)/timetable/page.tsx
@@ -134,8 +134,10 @@ const TimetablePage = () => {
 
   return (
     <div className="py-16 px-10 max-md:py-8 max-md:px-4">
-      <div className="w-full flex justify-between items-center pb-10 max-md:pb-5">
-        <h1 className="text-[32px] font-bold max-md:text-xl">컨퍼런스 시간표</h1>
+      <div className="w-full flex justify-between items-center pb-8 max-md:pb-5">
+        <h1 className="text-[#212121] dark:text-white text-[32px] font-bold max-md:text-xl">
+          컨퍼런스 시간표
+        </h1>
         {isLoggedIn ? (
           <button className="cursor-pointer p-1" onClick={handleWishlistClick}>
             {showWishlist || selectedTime ? (
@@ -148,9 +150,9 @@ const TimetablePage = () => {
           <div></div>
         )}
       </div>
-      <div className="flex gap-8 w-full ">
+      <div className="flex gap-6 w-full ">
         <div className="flex-grow">
-          <div className="pb-8 max-md:pb-4">
+          <div className="pb-6 max-md:pb-4">
             <DayTab
               days={['Day1', 'Day2', 'Day3']}
               selectedDay={selectedDay}
@@ -167,7 +169,7 @@ const TimetablePage = () => {
                   return (
                     <div
                       key={`empty-${start}`}
-                      className="flex justify-center items-center border border-[#E2E8F0] px-5 py-6 max-md:p-4 h-full text-center font-semibold text-base max-md:text-sm leading-[140%] text-[#757575] dark:bg-[#070A12] dark:border-[#161F2E] dark:text-[#62748E]"
+                      className="flex justify-center items-center border border-[#E2E8F0] px-5 py-6 bg-white max-md:p-4 h-full text-center font-semibold text-base max-md:text-sm leading-[140%] text-[#757575] dark:bg-[#070A12] dark:border-[#161F2E] dark:text-[#62748E]"
                     >
                       {start}
                       <br />-<br />
@@ -273,7 +275,7 @@ const TimetablePage = () => {
         </div>
 
         {selectedTime && !isMobile && (
-          <div className="w-[280px] flex-shrink-0 px-6 pt-11 h-full">
+          <div className="w-[280px] flex-shrink-0 px-0 pt-10 h-full">
             <h3 className="font-bold text-xl leading-[140%] pb-6">즐겨찾기 목록</h3>
             <div className="h-1/3 overflow-auto">
               {timeWish.length > 0 ? (
@@ -294,7 +296,7 @@ const TimetablePage = () => {
         )}
 
         {showWishlist && !isMobile && (
-          <div className="w-[280px] flex-shrink-0 px-6 pt-11 h-full">
+          <div className="w-[280px] flex-shrink-0 px-0 pt-10 h-full">
             <h3 className="font-bold text-xl leading-[140%] pb-6">즐겨찾기 목록</h3>
             <div className="h-full overflow-auto">
               {wishlist.length > 0 ? (

--- a/src/app/(route)/timetable/timetableComponent/ListCard.tsx
+++ b/src/app/(route)/timetable/timetableComponent/ListCard.tsx
@@ -41,7 +41,7 @@ const ListCard = ({ lectureList }: ListCardProps) => {
               <p className="w-fit text-[#001F85] dark:text-[#2E4BAE] py-[1px] font-semibold text-sm leading-[140%]">
                 {lecture.location}
               </p>
-              <BarSvg />
+              <BarSvg className="text-[#001F85] dark:text-[#2E4BAE]" />
               <span className="font-semibold text-sm leading-[140%] text-[#001F85] dark:text-[#2E4BAE]">
                 {new Date(lecture?.startTime).toLocaleTimeString('ko-KR', {
                   hour: '2-digit',
@@ -56,17 +56,15 @@ const ListCard = ({ lectureList }: ListCardProps) => {
                 })}
               </span>
             </div>
-            <span className="pt-3 pb-2 font-semibold text-base leading-[140%]">
-              {lecture?.title}
-            </span>
-            <p className="pb-4 text-[#757575] dark:text-[#62748E] font-medium text-sm leading-[140%]">
+            <span className="py-2 font-semibold text-base leading-[140%]">{lecture?.title}</span>
+            <p className="pb-5 text-[#757575] dark:text-[#62748E] font-medium text-sm leading-[140%]">
               {lecture.speakerName}
             </p>
-            <div className="flex w-full items-center gap-2">
+            <div className="flex w-full items-center gap-1">
               <WishButton
                 isWished={wishlist.some((w) => w.lectureId === getLectureId(lecture))}
                 itemId={getLectureId(lecture)}
-                className="w-11 h-11 bg-[#F1F5F9] dark:bg-[#0D121E]"
+                className="w-11 h-11 shrink-0 bg-[#F1F5F9] dark:bg-[#0D121E]"
                 iconClassName="w-6 h-6 text-[#00249C] dark:text-[#001A6F]"
                 onBeforeToggle={() => {
                   if (!accessToken) {

--- a/src/app/_components/TextViewer/TextViewer.tsx
+++ b/src/app/_components/TextViewer/TextViewer.tsx
@@ -25,7 +25,7 @@ const TextViewer = ({ desc, content, ...props }: Props) => {
       <EditorContent
         editor={editor}
         id="tiptap-editor"
-        className="prose prose-lg max-w-none p-4rounded-lg"
+        className="text-[#212121] dark:text-white prose prose-lg max-w-none p-4rounded-lg"
       />
     </div>
   );

--- a/src/app/assets/Timetable/Vector 3.svg
+++ b/src/app/assets/Timetable/Vector 3.svg
@@ -1,3 +1,3 @@
-<svg width="2" height="10" viewBox="0 0 2 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 0V10" stroke="#E2E8F0"/>
+<svg width="2" height="10" viewBox="0 0 2 10" fill="none" xmlns="http://www.w3.org/2000/svg" className='text-[#E2E8F0] dark:text-[#161F2E]'>
+<path d="M1 0V10" stroke="currentColor"/>
 </svg>


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/qa/lecture` → `dev`

<br/>

## ✅ 작업 내용

- 카카오 프로필 이미지 표시 오류 수정
- 시간표 페이지 디자인 QA 반영
  - 텍스트 색
  - 여백
  - 아이콘 색
  - 버튼 크기
- 강의 상세 페이지 디자인 QA 반영
  - 텍스트 색
  - 인풋 필드 포커싱
  - 버튼 크기
  - 질문 여러줄일때 정렬
  - 본인 질문만 수정/삭제 버튼 표시
- 강의 목록 페이지 디자인 QA 반영
  - 텍스트 색
  - rounded
  - 여백
  - 아이콘 크기
  - 목록에 카드 너비 조절해서 여백 없애는 것 -> 기존 방식 그대로 하기로 함

<br/>

## 🌠 이미지 첨부


<br/>

## ✏️ 앞으로의 과제

- 내일 할 일을
- 적어주세요

<br/>

## 📌 이슈 링크

- [`design/qa/lecture`] #156 
