### PR TITLE
design(lecture list, detail): 다크모드, 반응형 수정

### DIFF
--- a/src/app/(route)/lecture-list/component/list.tsx
+++ b/src/app/(route)/lecture-list/component/list.tsx
@@ -103,7 +103,7 @@ const LectureListPage = ({
         onSelectDay={setSelectedDay}
       />
       <div className="relative flex justify-between items-center h-10 mt-10 max-md:mt-5">
-        <h1 className="text-[#212121] text-lg font-medium leading-[140%] max-md:text-sm">
+        <h1 className="text-[#212121] dark:text-white text-lg font-medium leading-[140%] max-md:text-sm">
           <span className="text-[#015AFF] dark:text-[#014DD9]">{totalFilteredCount || 0}</span>{' '}
           lecture
         </h1>
@@ -190,7 +190,7 @@ const LectureListPage = ({
 
             return (
               <div key={time}>
-                <h2 className="text-[#212121] text-2xl font-bold mt-8 mb-4 max-md:text-lg max-md:my-4">
+                <h2 className="text-[#212121] dark:text-white text-2xl font-bold mt-8 mb-4 max-md:text-lg max-md:my-4">
                   {time}
                 </h2>
                 <ul className="flex flex-wrap gap-6 max-md:gap-3">

--- a/src/app/(route)/lecture/component/QuestionSection.tsx
+++ b/src/app/(route)/lecture/component/QuestionSection.tsx
@@ -173,7 +173,7 @@ const QuestionSection = () => {
         <div className="flex items-center justify-center resize-none w-full bg-[#F1F5F9] dark:bg-[#0D121E] rounded-xs focus-within:outline outline-[#015AFF] focus-within:bg-white dark:focus-within:outline-[#003AA5] dark:focus-within:bg-[#070A12]">
           <Textarea
             placeholder="사전 질문을 작성해 주세요."
-            className="text-[#212121] dark:text-white w-full border-none min-h-6 overflow-hidden resize-none border px-4 rounded-md focus:outline-none max-md:text-sm max-md:px-0"
+            className="text-[#212121] dark:text-white w-full border-none min-h-6 overflow-hidden resize-none border px-4 rounded-md focus:outline-none max-md:text-sm"
             value={text}
             onChange={(e) => setText(e.target.value)}
             rows={1}


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/qa/etc` → `dev`

<br/>

## ✅ 작업 내용

- 디자인 QA 중 빠트린 내용 수정

<br/>

## 🌠 이미지 첨부
| 강의 목록 다크모드 전 | 후 |
|---|---|
| ![스크린샷 2025-04-01 오전 9 06 50](https://github.com/user-attachments/assets/c4f315f4-0d6c-4f22-aeb3-b891a3a08892) | ![스크린샷 2025-04-01 오전 9 06 42](https://github.com/user-attachments/assets/c434b8a9-06a0-4698-ac10-cfb892f36cad) |

| 강의 상세 반응형 전 | 후 |
|---|---|
| ![스크린샷 2025-04-01 오전 9 05 59](https://github.com/user-attachments/assets/9a613208-3f06-4e4b-b52e-b68700f66d87) | ![스크린샷 2025-04-01 오전 9 06 11](https://github.com/user-attachments/assets/f4703ef4-b134-41d2-8648-2af36a41458d) |


<br/>

## ✏️ 앞으로의 과제

- 내일 할 일을
- 적어주세요

<br/>

## 📌 이슈 링크

- [`design/qa/etc`] #173 
